### PR TITLE
test(e2e): Provider sandbox E2E for Docker and K8s

### DIFF
--- a/ops/providers/docker/README.md
+++ b/ops/providers/docker/README.md
@@ -36,3 +36,10 @@ Mapping to profiles
 - H1 corresponds to Docker/Compose. Use this template with:
   - T2 (text-only) or T1 (web-only) profiles
   - T0 (exec) only when approvals and sandbox policies are in place
+
+E2E tests (opt-in)
+- These provider-hardening tests are optional and disabled by default.
+- Enable with: `INSPECT_E2E_SANDBOX=1 pytest -q -m sandbox_e2e -k docker`
+- The test brings `compose.yaml` up and verifies non-root UID/GID,
+  read-only rootfs, `no-new-privileges`, `cap_drop: [ALL]`, and a PIDs
+  limit. Teardown runs `docker compose down -v`.

--- a/ops/providers/k8s/README.md
+++ b/ops/providers/k8s/README.md
@@ -48,3 +48,14 @@ Example NetworkPolicy for N1
 - See `policies/networkpolicy-n1-proxy-egress.yaml` for a policy that
   allows egress only to kube-dns and a labeled in-namespace proxy. Apply
   it after deploying the sandbox and ensure your proxy enforces domains.
+
+E2E tests (opt-in)
+- Static defaults are validated via a lightweight test that inspects
+  `values.yaml`.
+- Runtime checks (namespace pod-security labels, container security
+  context, and default-deny egress) are opt-in to avoid CI dependencies.
+- Enable with: `INSPECT_E2E_SANDBOX=1 INSPECT_E2E_K8S_CHART=<chart>` and
+  run: `pytest -q -m sandbox_e2e -k k8s`.
+- Requires `kubectl`+`helm`, a working cluster, and the Inspect sandbox
+  chart. The test performs best-effort teardown (uninstall release and
+  delete the test namespace).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ markers = [
     "truncation: tests for tool-output truncation envelopes",
     "parallel: tests for parallel execution semantics",
     "model_flags: tests for model resolution flags and runners",
+    "sandbox_e2e: provider sandbox e2e tests (Docker/K8s; opt-in)",
     "benchmark: performance microbenchmarks (opt-in in CI)",
 ]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ testpaths = tests
 # and to avoid unknown-marker warnings during selection.
 markers =
     benchmark: performance and micro/macro benchmark tests
+    sandbox_e2e: provider sandbox e2e tests (Docker/K8s; opt-in)
     network: tests that require external network access
     truncation: tool/output truncation behavior and limits
     parallel: concurrency and parallel execution behavior

--- a/tests/e2e/test_sandbox_docker.py
+++ b/tests/e2e/test_sandbox_docker.py
@@ -1,0 +1,126 @@
+"""
+E2E: Hardened Docker provider checks (opt-in).
+
+This test exercises ops/providers/docker/compose.yaml to ensure the
+runtime container enforces key sandbox guarantees:
+ - Non-root UID/GID
+ - Read-only root filesystem
+ - No-new-privileges and ALL capabilities dropped
+ - PIDs limit set
+
+Opt-in only (never in default CI). Enable with:
+  INSPECT_E2E_SANDBOX=1 pytest -q -m sandbox_e2e
+
+Skips gracefully when Docker is unavailable or the env flag is unset.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.sandbox_e2e
+
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPOSE = ROOT / "ops/providers/docker/compose.yaml"
+
+
+def _enabled() -> bool:
+    val = os.getenv("INSPECT_E2E_SANDBOX", "").lower()
+    return val in {"1", "true", "yes", "on", "docker", "all"}
+
+
+def _check_prereqs() -> None:
+    if not _enabled():
+        pytest.skip("INSPECT_E2E_SANDBOX not enabled; skipping docker e2e")
+    if shutil.which("docker") is None:
+        pytest.skip("docker CLI not available; skipping")
+    # Prefer `docker compose`; fall back to legacy docker-compose if needed
+    if shutil.which("docker") is None and shutil.which("docker-compose") is None:
+        pytest.skip("docker compose not available; skipping")
+    if not COMPOSE.exists():
+        pytest.skip(f"compose template missing: {COMPOSE}")
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _compose_cmd() -> list[str]:
+    # Use the v2 plugin if present
+    return ["docker", "compose"] if shutil.which("docker") else ["docker-compose"]
+
+
+def _docker_inspect(name: str) -> dict:
+    out = _run(["docker", "inspect", name]).stdout
+    data = json.loads(out)
+    assert isinstance(data, list) and data, "docker inspect returned no data"
+    return data[0]
+
+
+@pytest.mark.network
+def test_docker_sandbox_hardening_end_to_end(tmp_path: Path) -> None:
+    _check_prereqs()
+
+    # Bring up the sandbox container in detached mode
+    up_cmd = _compose_cmd() + [
+        "-f",
+        str(COMPOSE),
+        "up",
+        "-d",
+    ]
+    down_cmd = _compose_cmd() + ["-f", str(COMPOSE), "down", "-v"]
+
+    try:
+        _run(up_cmd)
+
+        # Wait briefly for the container to become running
+        name = "inspect-sandbox"
+        for _ in range(20):
+            try:
+                state = _docker_inspect(name)["State"]["Running"]
+                if state:
+                    break
+            except Exception:
+                pass
+            time.sleep(0.25)
+
+        info = _docker_inspect(name)
+
+        # UID:GID non-root
+        user = info["Config"].get("User", "")
+        assert user in {"1000:1000", "1000"}, f"expected non-root user, got {user!r}"
+
+        # Read-only rootfs
+        assert info["HostConfig"].get("ReadonlyRootfs") is True
+
+        # PIDs limit
+        assert int(info["HostConfig"].get("PidsLimit", 0)) == 256
+
+        # No new privileges and cap drop ALL
+        sec_opts = info["HostConfig"].get("SecurityOpt", []) or []
+        assert any(isinstance(s, str) and s.startswith("no-new-privileges:") for s in sec_opts), (
+            f"no-new-privileges missing: {sec_opts}"
+        )
+
+        cap_drop = info["HostConfig"].get("CapDrop", []) or []
+        assert "ALL" in cap_drop, f"cap_drop missing ALL: {cap_drop}"
+
+    finally:
+        try:
+            _run(down_cmd)
+        except Exception:
+            # Best-effort teardown
+            pass

--- a/tests/e2e/test_sandbox_k8s.py
+++ b/tests/e2e/test_sandbox_k8s.py
@@ -1,0 +1,160 @@
+"""
+E2E: Hardened Kubernetes provider checks (opt-in).
+
+Two layers of validation:
+ 1) Static assertions on values.yaml defaults (always runs, fast)
+ 2) Optional runtime apply via Helm when explicitly enabled with env vars
+
+Enable runtime checks with:
+  INSPECT_E2E_SANDBOX=1 INSPECT_E2E_K8S_CHART=<chart-ref>
+  pytest -q -m sandbox_e2e -k k8s
+
+Skips gracefully when kubectl/helm are unavailable or env not set.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.sandbox_e2e
+
+
+ROOT = Path(__file__).resolve().parents[2]
+VALUES = ROOT / "ops/providers/k8s/values.yaml"
+
+
+def _enabled() -> bool:
+    val = os.getenv("INSPECT_E2E_SANDBOX", "").lower()
+    return val in {"1", "true", "yes", "on", "k8s", "all"}
+
+
+def _run(cmd: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        cmd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_values_security_defaults_static() -> None:
+    # Always perform static checks against the values file
+    text = VALUES.read_text(encoding="utf-8")
+
+    # NetworkPolicy defaults: enabled with default deny egress; preset N2
+    assert "networkPolicy:" in text
+    assert "enabled: true" in text
+    assert "defaultDenyEgress: true" in text
+    assert "netPreset: N2" in text
+
+    # Container security context: read-only rootfs and drop ALL caps
+    assert "containerSecurityContext:" in text
+    assert "readOnlyRootFilesystem: true" in text
+    assert 'drop: ["ALL"]' in text or 'drop: ["ALL"]' in text
+
+
+@pytest.mark.network
+def test_k8s_runtime_security_and_egress() -> None:
+    if not _enabled():
+        pytest.skip("INSPECT_E2E_SANDBOX not enabled; skipping k8s e2e")
+    if shutil.which("kubectl") is None or shutil.which("helm") is None:
+        pytest.skip("kubectl/helm not available; skipping")
+
+    chart = os.getenv("INSPECT_E2E_K8S_CHART")
+    if not chart:
+        pytest.skip("INSPECT_E2E_K8S_CHART not set; skipping runtime apply")
+
+    ns = "inspect-sandbox-e2e"
+    release = "inspect-sandbox-e2e"
+
+    # Namespace + pod security labels
+    _run(["kubectl", "create", "namespace", ns, "--dry-run=client", "-o", "yaml"])  # validate client-side
+    _run(
+        ["kubectl", "apply", "-f", "-"],
+    ).stdout
+    _run(
+        [
+            "kubectl",
+            "label",
+            "namespace",
+            ns,
+            "pod-security.kubernetes.io/enforce=restricted",
+            "pod-security.kubernetes.io/enforce-version=latest",
+            "--overwrite",
+        ]
+    )
+
+    try:
+        # Install/upgrade chart with hardened values
+        _run(
+            [
+                "helm",
+                "upgrade",
+                "--install",
+                release,
+                chart,
+                "-n",
+                ns,
+                "-f",
+                str(VALUES),
+            ]
+        )
+
+        # Wait for pod ready
+        _run(
+            ["kubectl", "wait", "--for=condition=Ready", "pod/-l", "app=inspect-sandbox", "-n", ns, "--timeout=90s"]
+        )  # label may differ by chart
+
+        # Grab first pod name
+        pods = _run(["kubectl", "get", "pods", "-n", ns, "-o", "json"]).stdout
+        items = json.loads(pods).get("items", [])
+        assert items, "no pods found in namespace"
+        pod = items[0]["metadata"]["name"]
+
+        # SecurityContext assertions
+        pod_json = json.loads(_run(["kubectl", "get", "pod", pod, "-n", ns, "-o", "json"]).stdout)
+        c0 = pod_json["spec"]["containers"][0]
+        sc = c0.get("securityContext", {})
+        assert sc.get("readOnlyRootFilesystem") is True
+        caps = (sc.get("capabilities", {}) or {}).get("drop", [])
+        assert "ALL" in caps
+
+        # Egress deny: try HTTP fetch and expect non-zero exit
+        # Ubuntu image may not have curl; try busybox wget via sh -c if present.
+        rc = subprocess.call(
+            [
+                "kubectl",
+                "exec",
+                pod,
+                "-n",
+                ns,
+                "--",
+                "sh",
+                "-lc",
+                "(command -v wget >/dev/null && wget -q --spider --timeout=3 http://example.com) || "
+                "(command -v curl >/dev/null && curl -sSf -m 3 http://example.com); echo $?",
+            ]
+        )
+        assert rc != 0, "egress unexpectedly allowed (expected default deny)"
+
+        # Namespace labels present
+        ns_json = json.loads(_run(["kubectl", "get", "ns", ns, "-o", "json"]).stdout)
+        labels = ns_json.get("metadata", {}).get("labels", {})
+        assert labels.get("pod-security.kubernetes.io/enforce") == "restricted"
+
+    finally:
+        # Teardown (best-effort)
+        try:
+            _run(["helm", "uninstall", release, "-n", ns])
+        except Exception:
+            pass
+        try:
+            _run(["kubectl", "delete", "namespace", ns, "--wait=false"])
+        except Exception:
+            pass


### PR DESCRIPTION
## Problem
- Validate and lock in hardened provider defaults for Inspect sandbox execution across Docker (H1) and Kubernetes (H2), and add opt‑in E2E tests to catch regressions in isolation and network presets without impacting default CI.

## Changes
- Added: `tests/e2e/test_sandbox_docker.py` – Compose‑based sandbox E2E that asserts:
  - Non‑root UID/GID (1000:1000)
  - Read‑only root filesystem
  - `no-new-privileges` security opt and `CapDrop: [ALL]`
  - `pids_limit: 256`
  - Best‑effort teardown via `docker compose down -v`; marked `sandbox_e2e` and `@pytest.mark.network`.
- Added: `tests/e2e/test_sandbox_k8s.py` – Kubernetes sandbox checks:
  - Static validation of `ops/providers/k8s/values.yaml` (readOnlyRootFilesystem, drop ALL caps, `netPreset: N2`, NetworkPolicy default‑deny egress)
  - Optional runtime checks (gated by `INSPECT_E2E_SANDBOX=1` and `INSPECT_E2E_K8S_CHART=<chart>`):
    - Namespace Pod Security labels (`restricted`), container `securityContext`, and default‑deny egress (negative HTTP fetch)
    - Best‑effort teardown (`helm uninstall` + namespace delete)
- Modified: `pytest.ini` – register `sandbox_e2e` marker (opt‑in E2E bucket).
- Modified: `pyproject.toml` – add `sandbox_e2e` marker to documented markers.
- Modified: `ops/providers/docker/README.md` – how to run Docker E2E; what is asserted; teardown.
- Modified: `ops/providers/k8s/README.md` – how to run K8s E2E; env flags; cleanup instructions.

## Risk and Rollback
- Risks:
  - Docker/K8s resources created during opt‑in E2E runs; potential residue if interrupted.
  - Runtime checks depend on local infra (docker, kubectl, helm).
- Mitigations:
  - Tests are opt‑in via `sandbox_e2e` marker and `INSPECT_E2E_SANDBOX=1` flag; default CI remains offline and unaffected.
  - Best‑effort teardown is implemented in both tests.
- Rollback:
  - Revert commits listed below to remove E2E tests and README notes.
  - No runtime/API changes; purely tests + docs.

## Test Plan
- Full suite (excluding opt‑in E2E):
  - Command:
    - `CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai uv run pytest -k "not sandbox_e2e" -ra`
  - Results:
    - 396 passed, 3 skipped, 3 deselected, 1 xfailed, 0 failed (23.78s)
  - Coverage:
    - Existing unit/integration suites across `inspect_agents` unchanged; new E2E guarded.
- Code Quality:
  - Linting: `uv run ruff check` → All checks passed!
  - Formatting: `uv run ruff format` → Repository‑standard formatting applied.
  - Type checking: `uv run pyright` (optional; may have pre‑existing warnings).
- Targeted E2E runs (opt‑in):
  - Docker: `INSPECT_E2E_SANDBOX=1 pytest -q -m sandbox_e2e -k docker`
  - K8s (runtime): `INSPECT_E2E_SANDBOX=1 INSPECT_E2E_K8S_CHART=<chart> pytest -q -m sandbox_e2e -k k8s`
  - Both will skip gracefully if prerequisites are missing.
- Manual smoke (optional):
  - Docker: `docker compose -f ops/providers/docker/compose.yaml up -d && docker compose -f ops/providers/docker/compose.yaml down -v`
  - K8s: apply values with your chart; verify pod is non‑root, read‑only rootfs, caps dropped, default‑deny egress.

## Context
- Source prompt: `prompts/FEATURE_PROMPT.txt` (Phase 04, Group A: Provider E2E Tests (Docker/K8s))
- Feature branch: `feat/p04-gA-provider-e2e-tests-dockerk8s`
- Commits:
  - `test(e2e): add provider hardening E2E (Docker/K8s)`
  - `ci(pytest): register sandbox_e2e marker`
  - `build(providers): add opt-in E2E run instructions`

## Rollout Notes
- Tests are infra‑gated and off by default. Enable locally or in dedicated CI jobs via `-m sandbox_e2e` and `INSPECT_E2E_SANDBOX=1`.
