### PR TITLE
test(legacy-guard): guard deprecated tests/inspect_agents; remove vestigial stub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@ This file governs engineering norms for this repository only. If your editor or 
 
 ### Project Structure
 - `src/inspect_agents/`: Inspect-AI-native library (agents, tools, state, config).
-- `tests/inspect_agents/`: Pytest suite for library behavior and shims.
+- `tests/unit/`: Unit tests (library behavior and shims).
+- `tests/integration/`: Integration tests (end-to-end flows, runners, examples).
 - `examples/inspect/`: CLI demos (`prompt_task.py`, `run.py`).
 - `env_templates/`: Example env file (`inspect.env`).
 - `external/inspect_ai/`: Inspect-AI source (submodule/checkout for local dev).
@@ -16,7 +17,7 @@ This file governs engineering norms for this repository only. If your editor or 
 - Install: `uv sync` (or `python3.11 -m venv .venv && pip install -e .`).
 - Run CLI task: `uv run inspect eval examples/inspect/prompt_task.py -T prompt="..."`.
 - Run Python runner: `uv run python examples/inspect/run.py "..."`.
-- Test: `CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai uv run pytest -q tests/inspect_agents`
+- Test: `CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai uv run pytest -q tests/unit tests/integration`
 
 ## 2. Development Guidelines
 
@@ -110,11 +111,11 @@ Always use:
 ## 5. Testing
 
 ### Running Tests
-**Default command**: `CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai uv run pytest -q tests/inspect_agents`
+**Default command**: `CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai uv run pytest -q tests/unit tests/integration`
 
 **Options**:
 - Subset testing: append `-k <expr>` (e.g., `-k sandbox`, `-k migration`)
-- Framework: pytest (tests in `tests/inspect_agents/`, named `test_*.py`)
+- Framework: pytest (tests in `tests/unit/**` and `tests/integration/**`, named `test_*.py`)
 - Default offline: `NO_NETWORK=1` for deterministic, fast tests
 - Lint (optional): `uv run ruff check`
 - Docs (optional): `uv run mkdocs serve`

--- a/docs/backlog/todo_feature_model_resolver_error_type.md
+++ b/docs/backlog/todo_feature_model_resolver_error_type.md
@@ -19,5 +19,5 @@
 - Implemented `ResolveModelError` carrying `.trace` and `.final_step`; `resolve_model(...)` continues to raise `RuntimeError` for backward compatibility while `resolve_model_explain(...)` raises `ResolveModelError`.
 - References:
   - Code: `src/inspect_agents/model.py`
-  - Tests: `tests/inspect_agents/test_model_resolver.py`
+- Tests: `tests/unit/inspect_agents/test_model_resolver.py`
   - Docs: `docs/how-to/model_resolver_explain.md`

--- a/docs/backlog/todo_feature_model_resolver_explain_api.md
+++ b/docs/backlog/todo_feature_model_resolver_explain_api.md
@@ -20,7 +20,7 @@
 - Implemented as a typed API returning `(str, ModelResolutionTrace)` with `ModelResolutionStep` entries and `ResolveModelError` for failures.
 - References:
   - Code: `src/inspect_agents/model.py`
-  - Tests: `tests/inspect_agents/test_model_resolver.py`
+- Tests: `tests/unit/inspect_agents/test_model_resolver.py`
   - Docs: `docs/how-to/model_resolver_explain.md`
 
 Notes

--- a/docs/backlog/todo_tests_model_explain_coverage.md
+++ b/docs/backlog/todo_tests_model_explain_coverage.md
@@ -7,7 +7,7 @@
 - Cases: openai with fake key (missing), `openai-api/lm-studio` with fake key/model, sentinel `none/none`, role-map with provider split, fallback with bare model.
 
 ## Scope Definition
-- Tests: implemented in `tests/inspect_agents/test_model_resolver.py` (covers explicit provider/model, role mapping, `INSPECT_EVAL_MODEL` override and sentinel, OpenAI‑compatible vendor path, missing key/model errors, fallback with bare model, and wrapper RuntimeError behavior).
+- Tests: implemented in `tests/unit/inspect_agents/test_model_resolver.py` (covers explicit provider/model, role mapping, `INSPECT_EVAL_MODEL` override and sentinel, OpenAI‑compatible vendor path, missing key/model errors, fallback with bare model, and wrapper RuntimeError behavior).
 
 ## Success Criteria
 - Deterministic pass with NO_NETWORK=1; asserts on `path` and `*_source` keys.

--- a/docs/design/open-questions.md
+++ b/docs/design/open-questions.md
@@ -740,7 +740,7 @@ Acceptance Criteria
 <summary>✅ Answer Found in Implementation</summary>
 
 **Finding**: A typed explain surface is implemented via `resolve_model_explain(...)` returning `(final: str, trace: ModelResolutionTrace)`. Each `ModelResolutionStep` in the trace includes `path`, `provider_arg`, `model_arg`, `role`, `role_env_model`, `role_env_provider`, `env_inspect_eval_model`, and optional `final_candidate`.
-**Evidence**: `src/inspect_agents/model.py` — `ModelResolutionStep` and `ModelResolutionTrace` definitions (L86–L109), `resolve_model_explain(...)` (L143–L231, L233–L389). Unit tests exercise the API and step labels in `tests/inspect_agents/test_model_resolver.py` (e.g., explicit path, role mapping, env override, vendor branches).
+**Evidence**: `src/inspect_agents/model.py` — `ModelResolutionStep` and `ModelResolutionTrace` definitions (L86–L109), `resolve_model_explain(...)` (L143–L231, L233–L389). Unit tests exercise the API and step labels in `tests/unit/inspect_agents/test_model_resolver.py` (e.g., explicit path, role mapping, env override, vendor branches).
 **Conclusion**: Explain surface is implemented with a typed trace (enriched fields). Remaining enrichment keys like `*_source` are optional enhancements (see item 4 below).
 
 </details>
@@ -883,7 +883,7 @@ Acceptance Criteria
 <summary>✅ Answer Found in Implementation</summary>
 
 **Finding**: Dedicated offline-safe tests cover the explain surface, branch labels, sentinel handling, vendor branches, and error paths.
-**Evidence**: `tests/inspect_agents/test_model_resolver.py` asserts `trace.steps[-1].path` across scenarios and validates `ResolveModelError` carries a trace.
+**Evidence**: `tests/unit/inspect_agents/test_model_resolver.py` asserts `trace.steps[-1].path` across scenarios and validates `ResolveModelError` carries a trace.
 **Conclusion**: Coverage is in place and deterministic (uses env monkeypatching, no network).
 
 </details>

--- a/docs/getting-started/inspect_agents_quickstart.md
+++ b/docs/getting-started/inspect_agents_quickstart.md
@@ -215,7 +215,7 @@ Call `inspect_agents.logging.write_transcript()` to persist JSONL events. Defaul
 Run a focused test to confirm the path works locally:
 
 ```bash
-pytest -q tests/inspect_agents/test_run.py::test_run_with_str_input_returns_state
+pytest -q tests/integration/inspect_agents/test_run.py::test_run_with_str_input_returns_state
 ```
 
 ## Standard Tools

--- a/tests/unit/test_structure.py
+++ b/tests/unit/test_structure.py
@@ -61,3 +61,30 @@ def test_no_legacy_tests_present() -> None:
         "Move tests to 'tests/unit/**' or 'tests/integration/**'.\n"
         "Offending paths:\n  - " + "\n  - ".join(sorted(offenders))
     )
+
+
+# --- Legacy Guard Cleanup (Group A / Phase 01) ---
+# Include deprecated test path in legacy roots guard.
+
+try:
+    _legacy_roots = list(LEGACY_ROOTS)  # type: ignore[name-defined]
+except NameError:
+    _legacy_roots = []
+except Exception:
+    try:
+        _legacy_roots = list(LEGACY_ROOTS)  # type: ignore[misc]
+    except Exception:
+        _legacy_roots = []
+
+_deprecated = Path("tests/inspect_agents")
+
+
+def _to_path(p: object) -> Path:
+    return p if isinstance(p, Path) else Path(str(p))
+
+
+if all(_to_path(p) != _deprecated for p in _legacy_roots):
+    _legacy_roots.append(_deprecated)
+
+LEGACY_ROOTS = _legacy_roots  # type: ignore[assignment]
+# --- End Legacy Guard Cleanup ---


### PR DESCRIPTION
## Problem
- Prevent contributors from adding new tests under the deprecated `tests/inspect_agents` path; keep test layout consistent with docs and enforce via a guard test in CI.

## What & Why
This PR formalizes the deprecation of `tests/inspect_agents/` by adding an explicit guard in `tests/unit/test_structure.py`, preventing new files from landing in the legacy path and keeping our unit/integration layout consistent across the repo and CI.

## Changes
- Update guard in `tests/unit/test_structure.py` to include `tests/inspect_agents/` as a forbidden legacy root.
- Remove vestigial package stub: `tests/inspect_agents/__init__.py`.
- Refresh docs to reflect unit/integration layout and deprecate `tests/inspect_agents/` references where present.

Changed files (vs base):

```
M	AGENTS.md
M	docs/backlog/todo_feature_model_resolver_error_type.md
M	docs/backlog/todo_feature_model_resolver_explain_api.md
M	docs/backlog/todo_tests_model_explain_coverage.md
M	docs/design/open-questions.md
M	docs/getting-started/inspect_agents_quickstart.md
D	tests/inspect_agents/__init__.py
M	tests/unit/test_structure.py
```

## Risk and Rollback
- Risks:
  - False positives if external docs or scripts rely on `tests/inspect_agents/`.
  - Minor churn if contributors have unmerged work under the legacy path.
- Mitigations:
  - Clear test failure messaging in the guard; doc updates included.
  - Simple rename/move guidance in contributor docs.
- Rollback:
  - Revert the guard changes in `tests/unit/test_structure.py` and restore the removed stub if needed.
  - No runtime code touched; safe to roll back without migration.

## Test Plan
- Full Test Suite (unit subset for this turn):
  - Command: `CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai pytest -r a tests/unit`
  - Results: 345 passed, 0 failed, 3 skipped; 63 warnings
  - Coverage: N/A in this run (CI to report)

- Targeted Tests:
  - `pytest -q tests/unit/test_structure.py` — guard passes locally.

- Manual Testing:
  - `find tests/inspect_agents -type f` outputs nothing (no files under deprecated path).
  - Creating a new file under `tests/inspect_agents/` should cause the guard test to fail.

## Context
- Source prompt: `prompts/FEATURE_PROMPT.txt`
- Feature branch: `feat/p01-gA-legacy-guard-cleanup`
- Commits:
  - test(legacy-guard): include deprecated tests/inspect_agents in guard; remove vestigial package stub
  - docs(tests): update docs to reflect unit/integration test layout
