### PR TITLE
feat: rename and relocate helper test to clarify intent

### DIFF
--- a/tests/unit/inspect_agents/run/__init__.py
+++ b/tests/unit/inspect_agents/run/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for inspect_agents.run."""

--- a/tests/unit/inspect_agents/run/test_run_my_helper_smoke.py
+++ b/tests/unit/inspect_agents/run/test_run_my_helper_smoke.py
@@ -20,7 +20,7 @@ def _install_stub_run(monkeypatch, sleep_s: float = 0.01, return_tuple: bool = T
 
 
 @pytest.mark.asyncio
-async def test_my_helper_smoke(monkeypatch):
+async def test_run_my_helper_smoke(monkeypatch):
     monkeypatch.setenv("NO_NETWORK", "1")
 
     # Provide a tiny runner time limit; our stub returns quickly.


### PR DESCRIPTION
## What & Why
Rename and relocate the helper test to clarify its intent and group it with other run-related tests. This makes the test purpose more obvious and improves organization within the test suite structure.

## Changes
- Rename `test_my_helper.py` to `test_run_my_helper_smoke.py` to clarify test intent
- Move test from `tests/unit/inspect_agents/` to `tests/unit/inspect_agents/run/` to group with other run-related tests
- Ensure `__init__.py` exists in the run test directory

**Affected areas**
`tests/unit/inspect_agents/run/`

## Risk & Rollback
**Risk checklist**
- [x] Breaking change (compat plan described) - N/A: no breaking changes
- [x] Data migration/backfill (plan + window) - N/A: no data changes
- [x] Security/privacy change (perms/secrets/PII) - N/A: no security changes
- [x] Performance impact (baseline vs. new) - N/A: no performance impact
- [x] Observability updated (metrics/logs/alerts) - N/A: no observability changes
- [x] Feature flag (name, rollout, kill-switch tested) - N/A: no feature flags

**Rollback**
Revert commit to restore original file location and name.

## Test Plan
**Automated**
- Unit: `pytest -q tests/unit/inspect_agents/run -k helper` - test runs from new location
- Integration/E2E: `pytest -q -k run_my_helper` - test is selectable with new naming pattern

**Manual / Evidence**
- Verified imports are package imports (no changes needed)
- Both test selection patterns work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)