### PR TITLE
Fix: centralize pytest markers and ensure limits selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ markers = [
     "truncation: tests for tool-output truncation envelopes",
     "parallel: tests for parallel execution semantics",
     "model_flags: tests for model resolution flags and runners",
+    "network: allow real network for this test",
     "sandbox_e2e: provider sandbox e2e tests (Docker/K8s; opt-in)",
     "benchmark: performance microbenchmarks (opt-in in CI)",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,13 +175,18 @@ if not _HAS_PYTEST_BENCHMARK:  # pragma: no cover - exercised only when plugin m
 
         return _runner
 
-    def pytest_configure(config):  # pragma: no cover - cosmetic marker registration
-        # Register the 'benchmark' marker to avoid unknown-mark warnings when
-        # the real plugin isn't installed.
-        try:
-            config.addinivalue_line("markers", "benchmark: no-op when pytest-benchmark is unavailable")
-        except Exception:
-            pass
+
+def _register_benchmark_marker(config) -> None:
+    """Ensure the fallback benchmark marker is only registered when needed."""
+
+    if _HAS_PYTEST_BENCHMARK:
+        return
+
+    try:
+        config.addinivalue_line("markers", "benchmark: no-op when pytest-benchmark is unavailable")
+    except Exception:
+        pass
+
 
 # Guard/cleanup fixture for approval-related tests that stub inspect_ai modules
 # and register global approvers. Ensures isolation across tests.
@@ -347,30 +352,7 @@ def _call_tools_module_guard():  # pragma: no cover - test infrastructure
 
 
 def pytest_configure(config):  # pragma: no cover - cosmetic marker registration
-    # Ensure common markers are known regardless of optional plugins
-    try:
-        config.addinivalue_line("markers", "benchmark: present even if pytest-benchmark is unavailable")
-    except Exception:
-        pass
-    try:
-        config.addinivalue_line("markers", "network: allow real network for this test")
-    except Exception:
-        pass
-    # Register repo markers used for selection/guides to avoid unknown-mark warnings
-    for _m in [
-        "approvals",
-        "handoff",
-        "filters",
-        "kill_switch",
-        "timeout",
-        "truncation",
-        "parallel",
-        "model_flags",
-    ]:
-        try:
-            config.addinivalue_line("markers", f"{_m}: repository-defined test marker")
-        except Exception:
-            pass
+    _register_benchmark_marker(config)
 
 
 # Optional dependency shim for `jsonlines` managed via fixture to ensure cleanup.

--- a/tests/integration/inspect_agents/test_parallel.py
+++ b/tests/integration/inspect_agents/test_parallel.py
@@ -53,7 +53,7 @@ def test_two_parallel_tools_both_execute():
     assert set(funcs) == {"echo_a", "echo_b"}
 
 
-def test_handoff_tool_declares_serial_execution():
+def test_parallel_limits_handoff_tool_declares_serial_execution():
     # Build a single subagent handoff tool
     tools = build_subagents(
         configs=[


### PR DESCRIPTION
## What & Why

  - Centralize pytest marker declarations in one place to avoid split brain
    between pyproject configuration and runtime hooks and keep the documented
    selectors working.

  Scope

  - No additional behavior changes beyond marker registration and selection.

  ## Changes

  - Register the fallback benchmark marker only when pytest-benchmark is missing
    and drop redundant marker wiring in tests/conftest.py.
  - Move all repository marker descriptions, including network, into
    pyproject.toml.
  - Rename the serial handoff test so pytest -q -m parallel -k limits executes
    a real target.

  Affected areas

  - tests/conftest.py
  - tests/integration/inspect_agents/test_parallel.py
  - pyproject.toml

  ## Risk & Rollback

  Risk checklist

  - [ ] Breaking change (compat plan described)
  - [ ] Data migration/backfill (plan + window)
  - [ ] Security/privacy change (perms/secrets/PII)
  - [ ] Performance impact (baseline vs. new)
  - [ ] Observability updated (metrics/logs/alerts)
  - [ ] Feature flag (name, rollout, kill-switch tested)

  Rollback

  - git revert d14f8bc and git revert 5f5dd22 or reset the branch to
    5f5dd22^.

  ## Test Plan

  Automated

  - Unit: pytest --markers
  - Integration/E2E: pytest -q -m parallel -k limits; pytest -q -m parallel

  Manual / Evidence

  - Steps + expected signals: Verified pytest --markers lists repository markers
    from TOML and pytest -q -m parallel -k limits runs the renamed test with no
    missing-selection failure.
  - UI (if applicable): n/a
  - Performance (if applicable): n/a

  ## Follow-ups (optional)

  - None.
