### PR TITLE
Add optional include_defaults flag for built-in tool injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,13 @@ python examples/inspect/quickstart_toy.py
 Setting up practical LLM agents is slow: you fight glue code, logging, state, and tool orchestration. Inspect Agents removes overhead with an Inspect‑AI‑native workflow: typed state (todos/files), built‑in tools, and rich transcripts/traces by default. You can run a toy agent offline in seconds (see Quickstart above).
 
 ## Key Features
-- ✅ Inspect‑native tools: Todos + virtual filesystem
-  - Default: in‑memory “store” (ephemeral; isolated per run)
+- ✅ Inspect-native tools: Todos + virtual filesystem
+  - Default: in-memory “store” (ephemeral; isolated per run)
   - Optional: sandbox (routes through Inspect’s `text_editor`/`bash_session`; delete disabled)
   - Sandbox quickstart: see [docs/how-to/filesystem_sandbox_quickstart.md](docs/how-to/filesystem_sandbox_quickstart.md)
+  - Advanced: set `include_defaults=False` on `build_supervisor`, `build_iterative_agent`,
+    or YAML configs to opt out of auto-injected todos/files while keeping prompts aligned
+    with your custom toolchain.
 - ✅ Optional standard tools (gated by env flags):
   - `INSPECT_ENABLE_THINK` (default on), `INSPECT_ENABLE_WEB_SEARCH` (auto when provider keys set),
     `INSPECT_ENABLE_EXEC`, `INSPECT_ENABLE_WEB_BROWSER`, `INSPECT_ENABLE_TEXT_EDITOR_TOOL` (default off)

--- a/src/inspect_agents/agents.py
+++ b/src/inspect_agents/agents.py
@@ -97,6 +97,7 @@ def build_supervisor(
     prompt: str,
     tools: Sequence[object] | None = None,
     *,
+    include_defaults: bool = True,
     attempts: int = 1,
     model: object | None = None,
     truncation: str = "disabled",
@@ -106,6 +107,10 @@ def build_supervisor(
     Args:
         prompt: Base instructions to prepend before standard guidance.
         tools: Additional Tools/ToolDefs/ToolSources to provide.
+        include_defaults: When True (default), prepend the built-in Todo/FS tools
+            and mention them in the prompt. When False, skip automatic tool
+            injection and omit the Todo section so custom deployments can supply
+            their own toolchain without prompt drift.
         attempts: Max attempts for submit-terminated loop.
         model: Optional Inspect model (string/Model/Agent). If None, uses default.
         truncation: Overflow policy for long conversations ("disabled" or "auto").
@@ -116,17 +121,20 @@ def build_supervisor(
     from inspect_ai.agent._react import react
 
     # Compose prompt with clear tool sections (Todo/FS + Standard)
-    tools = list(tools or [])
-    builtins = _built_in_tools()
-    tools = builtins + tools
+    extra_tools = list(tools or [])
+    builtins = _built_in_tools() if include_defaults else []
+    tools = builtins + extra_tools
 
-    full_prompt = (
-        (prompt or "").rstrip()
-        + "\n\n"
-        + BASE_PROMPT_HEADER
-        + BASE_PROMPT_TODOS
-        + _format_standard_tools_section(builtins)
-    )
+    tail_chunks = [BASE_PROMPT_HEADER]
+    if include_defaults:
+        tail_chunks.append(BASE_PROMPT_TODOS)
+    std_section = _format_standard_tools_section(tools)
+    if std_section:
+        tail_chunks.append(std_section)
+    tail = "".join(tail_chunks)
+
+    prefix = (prompt or "").rstrip()
+    full_prompt = tail if not prefix else f"{prefix}\n\n{tail}"
 
     return react(
         prompt=full_prompt,
@@ -142,6 +150,7 @@ def build_basic_submit_agent(
     *,
     prompt: str,
     tools: Sequence[object] | None = None,
+    include_defaults: bool = True,
     attempts: int = 1,
     model: object | None = None,
     truncation: str = "disabled",
@@ -154,6 +163,7 @@ def build_basic_submit_agent(
     return build_supervisor(
         prompt=prompt,
         tools=tools,
+        include_defaults=include_defaults,
         attempts=attempts,
         model=model,
         truncation=truncation,
@@ -165,6 +175,7 @@ def build_iterative_agent(
     prompt: str | None = None,
     tools: Sequence[object] | None = None,
     code_only: bool = False,
+    include_defaults: bool = True,
     model: Any | None = None,
     real_time_limit_sec: int | None = None,
     max_steps: int | None = None,
@@ -187,6 +198,7 @@ def build_iterative_agent(
         prompt=prompt,
         tools=tools,
         code_only=code_only,
+        include_defaults=include_defaults,
         model=model,
         real_time_limit_sec=real_time_limit_sec,
         max_steps=max_steps,

--- a/src/inspect_agents/config.py
+++ b/src/inspect_agents/config.py
@@ -39,6 +39,7 @@ class SupervisorCfg(BaseModel):
     attempts: int | None = None
     truncation: Literal["auto", "disabled"] | None = None
     model: Any | None = None
+    include_defaults: bool | None = None
 
 
 class SubAgentCfg(BaseModel):
@@ -330,9 +331,12 @@ def build_from_config(
 
     # Build supervisor
     sup = cfg.supervisor
+    include_defaults = True if sup.include_defaults is None else bool(sup.include_defaults)
+
     agent = build_supervisor(
         prompt=sup.prompt,
         tools=sub_tools,
+        include_defaults=include_defaults,
         attempts=sup.attempts or 1,
         model=model or sup.model,
         truncation=sup.truncation or "disabled",

--- a/src/inspect_agents/iterative.py
+++ b/src/inspect_agents/iterative.py
@@ -99,15 +99,16 @@ def _base_tools(*, code_only: bool = False) -> list[object]:
     return fs_tools + standard_tools()
 
 
-def _default_system_message(*, code_only: bool = False) -> str:
+def _default_system_message(*, code_only: bool = False, include_defaults: bool = True) -> str:
     base = (
         "You are an iterative coding agent.\n"
         "- Work in small, verifiable steps (one tool call per message).\n"
-        "- Read or edit files as needed; keep the repo tidy and reproducible.\n"
         "- Prefer updating existing files over creating many new ones.\n"
         "- If a step requires execution, use bash responsibly and capture outputs.\n"
         "- Continue improving until time is up or explicit stop.\n"
     )
+    if include_defaults:
+        base += "- Read or edit files as needed; keep the repo tidy and reproducible.\n"
     if code_only:
         base += "- Code-only mode: no exec/search/browser tools are available; prefer read/edit file tools.\n"
     return base
@@ -122,6 +123,7 @@ def build_iterative_agent(
     prompt: str | None = None,
     tools: Sequence[object] | None = None,
     code_only: bool = False,
+    include_defaults: bool = True,
     model: Any | None = None,
     real_time_limit_sec: int | None = None,
     max_steps: int | None = None,
@@ -157,7 +159,8 @@ def build_iterative_agent(
 
     Args:
         prompt: System instructions. If None, a sensible default is used.
-        tools: Tools to expose. Defaults to Files tools plus any enabled standard tools.
+        tools: Tools to expose. Defaults to Files tools plus any enabled standard tools
+            when `include_defaults=True`. When False, the caller must pass tools.
         model: Inspect model identifier or object. If None, current active model is used.
         real_time_limit_sec: Wall‑clock time budget for the agent (excludes provider retry backoff best‑effort). If None, falls back to the env var `INSPECT_ITERATIVE_TIME_LIMIT` (seconds) when set.
         max_steps: Hard cap on loop steps. If None, falls back to the env var `INSPECT_ITERATIVE_MAX_STEPS` when set.
@@ -198,9 +201,14 @@ def build_iterative_agent(
     from inspect_ai.model._model import get_model
     # Lightweight, provider-agnostic pruning already imported above
 
-    sys_message = prompt or _default_system_message(code_only=code_only)
+    sys_message = prompt or _default_system_message(
+        code_only=code_only,
+        include_defaults=include_defaults,
+    )
     step_nudge = continue_message or _default_continue_message()
-    active_tools = list(tools or _base_tools(code_only=code_only))
+    base_tools = _base_tools(code_only=code_only) if include_defaults else []
+    extra_tools = list(tools or [])
+    active_tools = base_tools + extra_tools if include_defaults else extra_tools
 
     @agent(name="iterative_supervisor")
     def _iterative() -> Any:

--- a/src/inspect_agents/migration.py
+++ b/src/inspect_agents/migration.py
@@ -7,7 +7,11 @@ from typing import Any
 from . import fs as _fs
 
 
-def _resolve_builtin_tools(names: list[str] | None) -> list[object]:
+def _resolve_builtin_tools(
+    names: list[str] | None,
+    *,
+    include_defaults: bool = True,
+) -> list[object]:
     from inspect_agents import tools as builtin
 
     name_to_ctor = {
@@ -18,7 +22,10 @@ def _resolve_builtin_tools(names: list[str] | None) -> list[object]:
         "edit_file": builtin.edit_file,
     }
 
-    selected = list(name_to_ctor.keys()) if names is None else names
+    if names is None:
+        selected = list(name_to_ctor.keys()) if include_defaults else []
+    else:
+        selected = names
     return [name_to_ctor[n]() for n in selected if n in name_to_ctor]
 
 
@@ -218,27 +225,52 @@ def create_deep_agent(
     interrupt_config: dict[str, Any] | None = None,
     attempts: int = 1,
     truncation: str = "disabled",
+    include_defaults: bool = True,
 ) -> object:
     """Drop-in constructor with deepagents-style compatibility (backed by Inspect).
 
     Maps the familiar legacy deepagents surface to Inspect's ReAct agent,
     sub-agents, and optional approval policies. Unused params are accepted for
     parity.
+
+    Args:
+        include_defaults: When True (default), inject the built-in todo/filesystem
+            tools and describe them in the prompt for compatibility. When False,
+            skip automatic injection so callers can provide their own toolchain
+            without prompt drift.
     """
     from inspect_ai.agent._agent import agent as as_agent
     from inspect_ai.agent._react import react
 
-    from inspect_agents.agents import BASE_PROMPT, build_subagents
+    from inspect_agents.agents import (
+        BASE_PROMPT_HEADER,
+        BASE_PROMPT_TODOS,
+        _format_standard_tools_section,
+        build_subagents,
+    )
 
     # Resolve built-ins and optional sub-agents
-    base_tools = _resolve_builtin_tools(builtin_tools)
+    base_tools = _resolve_builtin_tools(
+        builtin_tools,
+        include_defaults=include_defaults,
+    )
     extra_tools = list(tools or [])
 
     if subagents:
         extra_tools.extend(build_subagents(subagents, base_tools))
 
     # Build top-level ReAct supervisor
-    full_prompt = (instructions or "").rstrip() + "\n\n" + BASE_PROMPT
+    tail_chunks = [BASE_PROMPT_HEADER]
+    if include_defaults:
+        tail_chunks.append(BASE_PROMPT_TODOS)
+    std_section = _format_standard_tools_section(base_tools + extra_tools)
+    if std_section:
+        tail_chunks.append(std_section)
+
+    tail = "".join(tail_chunks)
+
+    prefix = (instructions or "").rstrip()
+    full_prompt = tail if not prefix else f"{prefix}\n\n{tail}"
     base_agent = react(
         prompt=full_prompt,
         tools=base_tools + extra_tools,

--- a/tests/unit/inspect_agents/config/test_config_loader.py
+++ b/tests/unit/inspect_agents/config/test_config_loader.py
@@ -4,7 +4,7 @@ import pytest
 from inspect_ai.agent._agent import AgentState, agent
 from inspect_ai.model._chat_message import ChatMessageAssistant
 
-from inspect_agents.config import load_and_build, load_yaml
+from inspect_agents.config import build_from_config, load_and_build, load_yaml
 from inspect_agents.run import run_agent
 
 
@@ -65,6 +65,34 @@ def test_minimal_yaml_builds_and_runs(monkeypatch):
     agent_obj, tools, approvals, limits = load_and_build(yaml_txt, model=toy_submit_model())
     result = asyncio.run(run_agent(agent_obj, "start", approval=approvals, limits=limits))
     assert "DONE" in (result.output.completion or "")
+
+
+def test_include_defaults_flag_forwarded(monkeypatch):
+    yaml_txt = """
+    supervisor:
+      prompt: "Skip defaults"
+      include_defaults: false
+    """
+
+    cfg = load_yaml(yaml_txt)
+
+    captured: dict[str, object] = {}
+
+    def fake_build_supervisor(*, prompt, tools, include_defaults, **kwargs):
+        captured["prompt"] = prompt
+        captured["tools"] = list(tools)
+        captured["include_defaults"] = include_defaults
+        return object()
+
+    monkeypatch.setattr("inspect_agents.config.build_supervisor", fake_build_supervisor)
+
+    agent, tools, approvals, limits = build_from_config(cfg)
+
+    assert captured["include_defaults"] is False
+    assert captured["prompt"].startswith("Skip defaults")
+    assert tools == []
+    assert approvals == []
+    assert limits == []
 
 
 def test_subagent_declared_and_handoff_tool_present(monkeypatch):

--- a/tests/unit/inspect_agents/migration/test_migration.py
+++ b/tests/unit/inspect_agents/migration/test_migration.py
@@ -59,3 +59,30 @@ def test_create_deep_agent_minimal_flow():
     # Verify todos updated in Store
     todos = store_as(Todos).get_todos()
     assert any(t.content == "do x" for t in todos)
+
+
+def test_create_deep_agent_respects_include_defaults(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def fake_resolver(names, *, include_defaults):
+        captured["include_defaults"] = include_defaults
+        return []
+
+    monkeypatch.setattr("inspect_agents.migration._resolve_builtin_tools", fake_resolver)
+
+    async def _dummy_agent(state):  # pragma: no cover - stub only
+        return state
+
+    def fake_react(**kwargs):
+        captured.update(kwargs)
+        return _dummy_agent
+
+    monkeypatch.setattr("inspect_ai.agent._react.react", fake_react)
+
+    agent_obj = create_deep_agent(tools=[], instructions="Hello", include_defaults=False)
+
+    assert callable(agent_obj)
+    assert captured["include_defaults"] is False
+    assert captured["tools"] == []
+    prompt = captured["prompt"]
+    assert "Todo & Filesystem Tools" not in prompt

--- a/tests/unit/inspect_agents/test_include_defaults.py
+++ b/tests/unit/inspect_agents/test_include_defaults.py
@@ -1,0 +1,70 @@
+from inspect_agents.agents import build_supervisor
+from inspect_agents.iterative import build_iterative_agent
+
+
+def test_build_supervisor_include_defaults_false_skips_builtin_tools(monkeypatch):
+    def raising_builtins():
+        raise AssertionError("_built_in_tools should not run when include_defaults is False")
+
+    monkeypatch.setattr("inspect_agents.agents._built_in_tools", raising_builtins)
+
+    captured: dict[str, object] = {}
+
+    async def _dummy_agent(state):  # pragma: no cover - stub only
+        return state
+
+    def fake_react(**kwargs):
+        captured.update(kwargs)
+        return _dummy_agent
+
+    monkeypatch.setattr("inspect_ai.agent._react.react", fake_react)
+
+    sentinel = object()
+    agent_obj = build_supervisor(prompt="Base", tools=[sentinel], include_defaults=False)
+
+    assert captured.get("tools") == [sentinel]
+    prompt = captured.get("prompt", "")
+    assert isinstance(prompt, str)
+    assert "Todo & Filesystem Tools" not in prompt
+    assert "You have access to a number of tools." in prompt
+    assert agent_obj is _dummy_agent
+
+
+def test_build_iterative_agent_include_defaults_false_skips_base_tools(monkeypatch):
+    def raising_base_tools(**_):
+        raise AssertionError("_base_tools should not run when include_defaults is False")
+
+    monkeypatch.setattr("inspect_agents.iterative._base_tools", raising_base_tools)
+
+    captured: dict[str, object] = {}
+
+    def fake_default_system_message(*, code_only: bool, include_defaults: bool) -> str:
+        captured["system_include_defaults"] = include_defaults
+        captured["code_only"] = code_only
+        return "prompt"
+
+    monkeypatch.setattr(
+        "inspect_agents.iterative._default_system_message",
+        fake_default_system_message,
+    )
+
+    def identity_agent(*, name=None):  # noqa: ARG001 - signature parity
+        def decorator(fn):
+            captured["iterative_fn"] = fn
+            return fn
+
+        return decorator
+
+    monkeypatch.setattr("inspect_ai.agent._agent.agent", identity_agent)
+
+    sentinel = object()
+    agent_obj = build_iterative_agent(include_defaults=False, tools=[sentinel])
+
+    assert callable(agent_obj)
+    assert captured["system_include_defaults"] is False
+    fn = captured["iterative_fn"]
+    assert fn is not None
+    closure_cells = fn.__closure__ or ()
+    freevars = fn.__code__.co_freevars
+    closure = {name: cell.cell_contents for name, cell in zip(freevars, closure_cells)}
+    assert closure["active_tools"] == [sentinel]


### PR DESCRIPTION
## What & Why

  - Add an include_defaults flag so advanced users can disable automatic todo and
    filesystem tool injection without forking.
  - Keeps legacy behavior by default while aligning prompts with available tools.

  Scope

  - Only supervisor/iterative builders, config loader, migration shim, docs, and
    new tests; no runtime tooling changes beyond the flag.

  ## Changes

  - Add include_defaults plumbing to supervisor, iterative, config, and migration
    builders so built-ins can be skipped when false.
  - Adjust prompts to omit Todo guidance when defaults are excluded.
  - Document the flag in the README for advanced integrators.
  - Add unit tests covering builder, config, and migration opt-out paths.

  Affected areas

  - src/inspect_agents/agents.py
  - src/inspect_agents/config.py
  - src/inspect_agents/iterative.py
  - src/inspect_agents/migration.py
  - tests/unit/inspect_agents/**
  - README.md

  ## Risk & Rollback

  Risk checklist

  - [ ] Breaking change (compat plan described)
  - [ ] Data migration/backfill (plan + window)
  - [ ] Security/privacy change (perms/secrets/PII)
  - [ ] Performance impact (baseline vs. new)
  - [ ] Observability updated (metrics/logs/alerts)
  - [ ] Feature flag (name, rollout, kill-switch tested)

  Rollback

  - Revert commits 92dd831, ea562b8, and 83c7e21.

  ## Test Plan

  Automated

  - Unit: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai UV_WORKSPACE=0 uv run --no_workspace pytest -q tests/unit/inspect_agents/test_include_defaults.py
  tests/unit/inspect_agents/migration/test_migration.py::test_create_deep_agent_respects_include_defaults
  - Integration/E2E: Full suite currently blocked by uv workspace expecting a
    pyproject.toml under external/inspect_ai; needs workspace fix before run.

  Manual / Evidence

  - Steps + expected signals: n/a (no manual testing performed).
  - UI (if applicable): n/a.
  - Performance (if applicable): n/a.

  ## Follow-ups (optional)

  - Resolve uv workspace configuration so CI can run uv run pytest -q tests/unit tests/integration.