### PR TITLE
Add curated tool presets and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Setting up practical LLM agents is slow: you fight glue code, logging, state, an
   - Advanced: set `include_defaults=False` on `build_supervisor`, `build_iterative_agent`,
     or YAML configs to opt out of auto-injected todos/files while keeping prompts aligned
     with your custom toolchain.
+  - Curated presets: call `inspect_agents.tools.minimal_fs_preset()` (Todos + FS) or
+    `inspect_agents.tools.full_safe_preset()` (Todos + FS + env-gated standard tools)
+    to rebuild safe bundles when you disable defaults.
 - ✅ Optional standard tools (gated by env flags):
   - `INSPECT_ENABLE_THINK` (default on), `INSPECT_ENABLE_WEB_SEARCH` (auto when provider keys set),
     `INSPECT_ENABLE_EXEC`, `INSPECT_ENABLE_WEB_BROWSER`, `INSPECT_ENABLE_TEXT_EDITOR_TOOL` (default off)

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -31,6 +31,28 @@ Tools are grouped as follows:
 
 See also: ../guides/tool-umbrellas.md and ../guides/stateless-vs-stateful-tools-harmonized.md.
 
+## Presets
+
+Use curated presets to rebuild safe tool bundles when you disable automatic
+defaults (`include_defaults=False` on agents or YAML configs):
+
+- `inspect_agents.tools.minimal_fs_preset()` — Todos + filesystem wrappers only.
+- `inspect_agents.tools.full_safe_preset()` — Minimal preset plus any
+  env-gated standard tools returned by `standard_tools()`.
+
+Example:
+
+```python
+from inspect_agents.agents import build_supervisor
+from inspect_agents.tools import full_safe_preset
+
+agent = build_supervisor(
+    prompt="Review the patch notes and summarize",
+    include_defaults=False,
+    tools=full_safe_preset(),
+)
+```
+
 ## Return Types Summary
 
 Many tools support two return styles controlled by the `INSPECT_AGENTS_TYPED_RESULTS` env var.

--- a/src/inspect_agents/agents.py
+++ b/src/inspect_agents/agents.py
@@ -77,20 +77,11 @@ def _format_standard_tools_section(all_tools: list[object]) -> str:
 
 
 def _built_in_tools():
-    # Local imports to avoid importing inspect_ai at module import time
-    from inspect_agents.tools import (
-        edit_file,
-        ls,
-        read_file,
-        standard_tools,
-        update_todo_status,
-        write_file,
-        write_todos,
-    )
+    # Local import to avoid importing inspect_ai at module import time
+    from inspect_agents.tools import full_safe_preset
 
-    base = [write_todos(), update_todo_status(), write_file(), read_file(), ls(), edit_file()]
-    # Append optional standard tools (enabled via env flags)
-    return base + standard_tools()
+    # Mirrors full_safe_preset() so defaults stay in sync with curated presets
+    return full_safe_preset()
 
 
 def build_supervisor(
@@ -106,7 +97,9 @@ def build_supervisor(
 
     Args:
         prompt: Base instructions to prepend before standard guidance.
-        tools: Additional Tools/ToolDefs/ToolSources to provide.
+        tools: Additional Tools/ToolDefs/ToolSources to provide. Pass the result of
+            ``inspect_agents.tools.minimal_fs_preset()`` or ``full_safe_preset()``
+            when you disable defaults but still want curated bundles.
         include_defaults: When True (default), prepend the built-in Todo/FS tools
             and mention them in the prompt. When False, skip automatic tool
             injection and omit the Todo section so custom deployments can supply
@@ -188,7 +181,10 @@ def build_iterative_agent(
 ):
     """Thin passthrough to the iterative supervisor (no submit semantics).
 
-    Exposed here for a consistent surface alongside `build_supervisor()`.
+    Exposed here for a consistent surface alongside `build_supervisor()`. When
+    opting out of defaults via ``include_defaults=False``, reuse
+    ``inspect_agents.tools.minimal_fs_preset()`` or ``full_safe_preset()`` to
+    assemble sanctioned tool bundles without reimplementing policy checks.
     See `inspect_agents.iterative.build_iterative_agent` for parameter docs.
     """
     # Import locally to avoid heavy imports at module load

--- a/src/inspect_agents/tools.py
+++ b/src/inspect_agents/tools.py
@@ -243,6 +243,33 @@ def standard_tools() -> list[object]:
     return tools
 
 
+def minimal_fs_preset() -> list[object]:
+    """Return Todo and filesystem wrapper tools only.
+
+    Each call constructs fresh tool instances so callers do not share state
+    between agents or test runs.
+    """
+
+    return [
+        write_todos(),
+        update_todo_status(),
+        write_file(),
+        read_file(),
+        ls(),
+        edit_file(),
+    ]
+
+
+def full_safe_preset() -> list[object]:
+    """Return the minimal preset plus any enabled standard tools.
+
+    Standard tools remain gated by environment flags via ``standard_tools()``
+    so deployments can opt into exec/search/browser capabilities explicitly.
+    """
+
+    return minimal_fs_preset() + standard_tools()
+
+
 def write_todos():  # -> Tool
     """Update the shared todo list.
 

--- a/tests/unit/inspect_agents/tools/test_tool_presets.py
+++ b/tests/unit/inspect_agents/tools/test_tool_presets.py
@@ -1,0 +1,70 @@
+from collections.abc import Iterable
+
+
+def _tool_names(tools: Iterable[object]) -> set[str]:
+    from inspect_ai.tool._tool_def import ToolDef
+
+    names: set[str] = set()
+    for tool in tools:
+        try:
+            tdef = tool if isinstance(tool, ToolDef) else ToolDef(tool)
+            names.add(tdef.name)
+        except Exception:
+            # Ignore uninspectable callables; presets should not include them.
+            pass
+    return names
+
+
+def test_minimal_fs_preset_only_todo_and_fs(monkeypatch):
+    monkeypatch.delenv("INSPECT_ENABLE_THINK", raising=False)
+    monkeypatch.delenv("INSPECT_ENABLE_WEB_SEARCH", raising=False)
+    monkeypatch.delenv("INSPECT_ENABLE_EXEC", raising=False)
+    monkeypatch.delenv("INSPECT_ENABLE_WEB_BROWSER", raising=False)
+    monkeypatch.delenv("INSPECT_ENABLE_TEXT_EDITOR_TOOL", raising=False)
+
+    from inspect_agents.tools import minimal_fs_preset
+
+    names = _tool_names(minimal_fs_preset())
+    assert names == {
+        "write_todos",
+        "update_todo_status",
+        "write_file",
+        "read_file",
+        "ls",
+        "edit_file",
+    }
+
+
+def test_full_safe_preset_respects_disabled_standard(monkeypatch):
+    monkeypatch.setenv("INSPECT_ENABLE_THINK", "0")
+    monkeypatch.setenv("INSPECT_ENABLE_WEB_SEARCH", "0")
+    monkeypatch.setenv("INSPECT_ENABLE_EXEC", "0")
+    monkeypatch.setenv("INSPECT_ENABLE_WEB_BROWSER", "0")
+    monkeypatch.setenv("INSPECT_ENABLE_TEXT_EDITOR_TOOL", "0")
+
+    from inspect_agents.tools import full_safe_preset
+
+    names = _tool_names(full_safe_preset())
+    assert {
+        "write_todos",
+        "update_todo_status",
+        "write_file",
+        "read_file",
+        "ls",
+        "edit_file",
+    } == names
+    assert "bash_session" not in names
+
+
+def test_full_safe_preset_includes_exec_when_enabled(monkeypatch):
+    monkeypatch.setenv("INSPECT_ENABLE_THINK", "0")
+    monkeypatch.setenv("INSPECT_ENABLE_WEB_SEARCH", "0")
+    monkeypatch.setenv("INSPECT_ENABLE_WEB_BROWSER", "0")
+    monkeypatch.setenv("INSPECT_ENABLE_TEXT_EDITOR_TOOL", "0")
+    monkeypatch.setenv("INSPECT_ENABLE_EXEC", "1")
+
+    from inspect_agents.tools import full_safe_preset
+
+    names = _tool_names(full_safe_preset())
+    assert {"bash", "python"}.issubset(names)
+    assert "bash_session" not in names


### PR DESCRIPTION
## What & Why
Introduce curated tool preset helpers so callers who disable defaults
can assemble sanctioned bundles. Document the presets and add regression
tests for environment gated behavior.

**Scope**
No additional agent modes or approval policies are modified.

## Changes
- add minimal_fs_preset and full_safe_preset factories and reuse them
  in agent defaults
- document preset usage in README and tools reference, including a
  sample snippet
- add targeted pytest coverage that verifies env toggles shape preset
  membership

**Affected areas**
src/inspect_agents/
docs/
tests/unit/inspect_agents/tools/

## Risk & Rollback
**Risk checklist**
- [ ] Breaking change (compat plan described)
- [ ] Data migration/backfill (plan + window)
- [ ] Security/privacy change (perms/secrets/PII)
- [ ] Performance impact (baseline vs. new)
- [ ] Observability updated (metrics/logs/alerts)
- [ ] Feature flag (name, rollout, kill-switch tested)

**Rollback**
Revert commits a9aa0f4, fed2ba1, and 95bf5c2 or reset the branch to
origin/inspect-ai-rewrite.

## Test Plan
**Automated**
- Unit: ran CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python
  -m pytest -q tests/unit/inspect_agents/tools (pass)
- Integration/E2E: Not run (unchanged surfaces)

**Manual / Evidence**
- Steps + expected signals: Not required (no manual flows)
- UI (if applicable): Not applicable
- Performance (if applicable): Not applicable

## Follow-ups (optional)
- None
