### PR TITLE
feat: track include-default overrides via env-aware telemetry

### DIFF
--- a/docs/how-to/operations_logging_tracing.md
+++ b/docs/how-to/operations_logging_tracing.md
@@ -59,6 +59,11 @@ Fields include `tool`, `phase` (`start|end|error`), optional `duration_ms`, and 
 - Redaction keys: `api_key`, `authorization`, `token`, `password`, `file_text`, `content`. 〖F:src/inspect_agents/approval.py†L113-L124〗
 - Truncation: long string fields shortened (default 200 chars) — set `INSPECT_TOOL_OBS_TRUNCATE` to adjust. 〖F:src/inspect_agents/tools.py†L46-L53〗 〖F:src/inspect_agents/tools.py†L79-L116〗
 
+### Default tool inclusion telemetry
+When you call `build_supervisor(...)` or `build_iterative_agent(...)`, Inspect Agents emits a single `tool_event` named `agent_defaults` summarizing whether built-in tools were injected. The payload includes the builder (`supervisor` or `iterative`), the final `include_defaults` decision, how many caller-supplied tools were provided, and whether replacements were supplied when defaults are disabled. The log also records a future-facing feature flag name (`INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS`) and its current state so deployments can correlate opt-outs with config rollout plans. The `include_defaults_source` field explains whether the value came from the explicit argument, the environment flag, or the built-in default, and additional context such as the total active tool count and `code_only` mode accompanies the event.
+
+Use it to audit custom profiles that disable defaults and confirm they provision alternative tooling before launching experiments. Setting `INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS=0/1` globally flips the default tool injection; the resulting record will note the environment source while still allowing explicit overrides per call. Each builder call emits at most one record, keeping transcripts low-noise while still capturing opt-out adoption.
+
 ## Common patterns
 - Find all approval rejections/terminations:
 ```bash

--- a/src/inspect_agents/agents.py
+++ b/src/inspect_agents/agents.py
@@ -11,6 +11,9 @@ via the default `submit()` tool provided by Inspect.
 from collections.abc import Sequence
 from typing import Any, NotRequired, TypedDict
 
+from .observability import log_agent_defaults_event
+from .settings import resolve_include_defaults
+
 # Base prompt modeled for legacy compatibility (deepagents-style base_prompt);
 # see migration.py and docs/design/deepagents_implementation_prompts.md.
 BASE_PROMPT_HEADER = "You have access to a number of tools.\n\n"
@@ -88,7 +91,7 @@ def build_supervisor(
     prompt: str,
     tools: Sequence[object] | None = None,
     *,
-    include_defaults: bool = True,
+    include_defaults: bool | None = None,
     attempts: int = 1,
     model: object | None = None,
     truncation: str = "disabled",
@@ -100,10 +103,11 @@ def build_supervisor(
         tools: Additional Tools/ToolDefs/ToolSources to provide. Pass the result of
             ``inspect_agents.tools.minimal_fs_preset()`` or ``full_safe_preset()``
             when you disable defaults but still want curated bundles.
-        include_defaults: When True (default), prepend the built-in Todo/FS tools
-            and mention them in the prompt. When False, skip automatic tool
-            injection and omit the Todo section so custom deployments can supply
-            their own toolchain without prompt drift.
+        include_defaults: When None (default), fall back to the environment
+            toggle `INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS` (defaults to True when
+            unset). When True, prepend the built-in Todo/FS tools and mention
+            them in the prompt. When False, skip automatic injection so custom
+            deployments can supply their own toolchain without prompt drift.
         attempts: Max attempts for submit-terminated loop.
         model: Optional Inspect model (string/Model/Agent). If None, uses default.
         truncation: Overflow policy for long conversations ("disabled" or "auto").
@@ -114,12 +118,23 @@ def build_supervisor(
     from inspect_ai.agent._react import react
 
     # Compose prompt with clear tool sections (Todo/FS + Standard)
+    resolved_include_defaults, include_source, env_raw = resolve_include_defaults(include_defaults)
+
     extra_tools = list(tools or [])
-    builtins = _built_in_tools() if include_defaults else []
+    builtins = _built_in_tools() if resolved_include_defaults else []
     tools = builtins + extra_tools
 
+    log_agent_defaults_event(
+        builder="supervisor",
+        include_defaults=resolved_include_defaults,
+        caller_supplied_tool_count=len(extra_tools),
+        feature_flag_state=env_raw,
+        include_defaults_source=include_source,
+        extra={"active_tool_count": len(tools)},
+    )
+
     tail_chunks = [BASE_PROMPT_HEADER]
-    if include_defaults:
+    if resolved_include_defaults:
         tail_chunks.append(BASE_PROMPT_TODOS)
     std_section = _format_standard_tools_section(tools)
     if std_section:
@@ -143,7 +158,7 @@ def build_basic_submit_agent(
     *,
     prompt: str,
     tools: Sequence[object] | None = None,
-    include_defaults: bool = True,
+    include_defaults: bool | None = None,
     attempts: int = 1,
     model: object | None = None,
     truncation: str = "disabled",
@@ -168,7 +183,7 @@ def build_iterative_agent(
     prompt: str | None = None,
     tools: Sequence[object] | None = None,
     code_only: bool = False,
-    include_defaults: bool = True,
+    include_defaults: bool | None = None,
     model: Any | None = None,
     real_time_limit_sec: int | None = None,
     max_steps: int | None = None,

--- a/src/inspect_agents/config.py
+++ b/src/inspect_agents/config.py
@@ -331,12 +331,10 @@ def build_from_config(
 
     # Build supervisor
     sup = cfg.supervisor
-    include_defaults = True if sup.include_defaults is None else bool(sup.include_defaults)
-
     agent = build_supervisor(
         prompt=sup.prompt,
         tools=sub_tools,
-        include_defaults=include_defaults,
+        include_defaults=sup.include_defaults,
         attempts=sup.attempts or 1,
         model=model or sup.model,
         truncation=sup.truncation or "disabled",

--- a/src/inspect_agents/iterative.py
+++ b/src/inspect_agents/iterative.py
@@ -35,7 +35,9 @@ from .iterative_runtime import (
     _remaining_timeout,
     _should_emit_progress,
 )
+from .observability import log_agent_defaults_event
 from .settings import max_tool_output_env as _max_tool_output_env
+from .settings import resolve_include_defaults
 
 # Bind transcript and error types at import time to avoid order-dependent
 # re-import issues in test environments that stub inspect_ai submodules.
@@ -123,7 +125,7 @@ def build_iterative_agent(
     prompt: str | None = None,
     tools: Sequence[object] | None = None,
     code_only: bool = False,
-    include_defaults: bool = True,
+    include_defaults: bool | None = None,
     model: Any | None = None,
     real_time_limit_sec: int | None = None,
     max_steps: int | None = None,
@@ -160,7 +162,11 @@ def build_iterative_agent(
     Args:
         prompt: System instructions. If None, a sensible default is used.
         tools: Tools to expose. Defaults to Files tools plus any enabled standard tools
-            when `include_defaults=True`. When False, the caller must pass tools.
+            when the resolved include-defaults setting is True.
+        include_defaults: When None (default), defer to the environment toggle
+            `INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS` (defaults to True when unset).
+            When True, expose the built-in Files + standard tools. When False,
+            the caller must pass tools explicitly.
         model: Inspect model identifier or object. If None, current active model is used.
         real_time_limit_sec: Wall‑clock time budget for the agent (excludes provider retry backoff best‑effort). If None, falls back to the env var `INSPECT_ITERATIVE_TIME_LIMIT` (seconds) when set.
         max_steps: Hard cap on loop steps. If None, falls back to the env var `INSPECT_ITERATIVE_MAX_STEPS` when set.
@@ -201,14 +207,28 @@ def build_iterative_agent(
     from inspect_ai.model._model import get_model
     # Lightweight, provider-agnostic pruning already imported above
 
+    resolved_include_defaults, include_source, env_raw = resolve_include_defaults(include_defaults)
+
     sys_message = prompt or _default_system_message(
         code_only=code_only,
-        include_defaults=include_defaults,
+        include_defaults=resolved_include_defaults,
     )
     step_nudge = continue_message or _default_continue_message()
-    base_tools = _base_tools(code_only=code_only) if include_defaults else []
+    base_tools = _base_tools(code_only=code_only) if resolved_include_defaults else []
     extra_tools = list(tools or [])
-    active_tools = base_tools + extra_tools if include_defaults else extra_tools
+    active_tools = base_tools + extra_tools if resolved_include_defaults else extra_tools
+
+    log_agent_defaults_event(
+        builder="iterative",
+        include_defaults=resolved_include_defaults,
+        caller_supplied_tool_count=len(extra_tools),
+        feature_flag_state=env_raw,
+        include_defaults_source=include_source,
+        extra={
+            "code_only": bool(code_only),
+            "active_tool_count": len(active_tools),
+        },
+    )
 
     @agent(name="iterative_supervisor")
     def _iterative() -> Any:

--- a/src/inspect_agents/migration.py
+++ b/src/inspect_agents/migration.py
@@ -5,12 +5,13 @@ from collections.abc import Sequence
 from typing import Any
 
 from . import fs as _fs
+from .settings import resolve_include_defaults
 
 
 def _resolve_builtin_tools(
     names: list[str] | None,
     *,
-    include_defaults: bool = True,
+    include_defaults: bool | None = None,
 ) -> list[object]:
     from inspect_agents import tools as builtin
 
@@ -22,8 +23,10 @@ def _resolve_builtin_tools(
         "edit_file": builtin.edit_file,
     }
 
+    include_defaults_bool, _, _ = resolve_include_defaults(include_defaults)
+
     if names is None:
-        selected = list(name_to_ctor.keys()) if include_defaults else []
+        selected = list(name_to_ctor.keys()) if include_defaults_bool else []
     else:
         selected = names
     return [name_to_ctor[n]() for n in selected if n in name_to_ctor]
@@ -225,7 +228,7 @@ def create_deep_agent(
     interrupt_config: dict[str, Any] | None = None,
     attempts: int = 1,
     truncation: str = "disabled",
-    include_defaults: bool = True,
+    include_defaults: bool | None = None,
 ) -> object:
     """Drop-in constructor with deepagents-style compatibility (backed by Inspect).
 
@@ -234,10 +237,12 @@ def create_deep_agent(
     parity.
 
     Args:
-        include_defaults: When True (default), inject the built-in todo/filesystem
-            tools and describe them in the prompt for compatibility. When False,
-            skip automatic injection so callers can provide their own toolchain
-            without prompt drift.
+        include_defaults: When None (default), defer to the environment toggle
+            `INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS` (defaults True when unset).
+            When True, inject the built-in todo/filesystem tools and describe
+            them in the prompt for compatibility. When False, skip automatic
+            injection so callers can provide their own toolchain without prompt
+            drift.
     """
     from inspect_ai.agent._agent import agent as as_agent
     from inspect_ai.agent._react import react
@@ -250,9 +255,11 @@ def create_deep_agent(
     )
 
     # Resolve built-ins and optional sub-agents
+    resolved_include_defaults, _, _ = resolve_include_defaults(include_defaults)
+
     base_tools = _resolve_builtin_tools(
         builtin_tools,
-        include_defaults=include_defaults,
+        include_defaults=resolved_include_defaults,
     )
     extra_tools = list(tools or [])
 
@@ -261,7 +268,7 @@ def create_deep_agent(
 
     # Build top-level ReAct supervisor
     tail_chunks = [BASE_PROMPT_HEADER]
-    if include_defaults:
+    if resolved_include_defaults:
         tail_chunks.append(BASE_PROMPT_TODOS)
     std_section = _format_standard_tools_section(base_tools + extra_tools)
     if std_section:

--- a/src/inspect_agents/observability.py
+++ b/src/inspect_agents/observability.py
@@ -13,6 +13,7 @@ from .settings import max_tool_output_env as _max_tool_output_env
 # Public exports
 __all__ = [
     "log_tool_event",
+    "log_agent_defaults_event",
     "maybe_emit_effective_tool_output_limit_log",
     "get_effective_tool_output_limit",
 ]
@@ -239,3 +240,45 @@ def log_tool_event(
         maybe_emit_effective_tool_output_limit_log()
 
     return now if phase == "start" else (t0 or now)
+
+
+def log_agent_defaults_event(
+    *,
+    builder: str,
+    include_defaults: bool,
+    caller_supplied_tool_count: int,
+    feature_flag_env: str = "INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS",
+    feature_flag_state: str | None = None,
+    include_defaults_source: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """Emit telemetry for include_defaults usage on agent construction.
+
+    Telemetry is best-effort; failures are swallowed to avoid impacting callers.
+    """
+    if feature_flag_state is None:
+        try:
+            flag_val = os.getenv(feature_flag_env)
+        except Exception:
+            flag_val = None
+    else:
+        flag_val = feature_flag_state
+
+    payload: dict[str, Any] = {
+        "builder": builder,
+        "include_defaults": bool(include_defaults),
+        "caller_supplied_tool_count": int(caller_supplied_tool_count),
+        "caller_supplied_replacements": bool(caller_supplied_tool_count > 0),
+        "feature_flag": feature_flag_env,
+        "feature_flag_state": flag_val if flag_val is not None else "unset",
+    }
+    if include_defaults_source:
+        payload.setdefault("include_defaults_source", include_defaults_source)
+    if extra:
+        for key, value in extra.items():
+            payload.setdefault(key, value)
+
+    try:
+        log_tool_event(name="agent_defaults", phase="info", extra=payload)
+    except Exception:
+        pass

--- a/src/inspect_agents/settings.py
+++ b/src/inspect_agents/settings.py
@@ -85,6 +85,50 @@ def default_tool_timeout() -> float:
     return float_env("INSPECT_AGENTS_TOOL_TIMEOUT", 15.0)
 
 
+_FALSEY = {"0", "false", "no", "off"}
+_FEATURE_FLAG_INCLUDE_DEFAULTS = "INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS"
+
+
+def include_defaults_env() -> tuple[bool | None, str | None]:
+    """Return (bool, raw) for the include-defaults feature flag.
+
+    - True/False when the environment specifies an explicit toggle.
+    - (None, raw) when unset or invalid so callers can fall back to defaults
+      while still surfacing the provided text in telemetry.
+    """
+
+    raw = os.getenv(_FEATURE_FLAG_INCLUDE_DEFAULTS)
+    if raw is None:
+        return None, None
+
+    value = raw.strip()
+    if value == "":
+        return None, raw
+
+    lowered = value.lower()
+    if truthy(lowered):
+        return True, raw
+    if lowered in _FALSEY:
+        return False, raw
+    return None, raw
+
+
+def resolve_include_defaults(explicit: bool | None) -> tuple[bool, str, str | None]:
+    """Resolve include-defaults preference with env override semantics.
+
+    Returns a tuple of `(include_defaults, source, env_raw)` where `source` is
+    one of "explicit", "env", or "default". Defaults to True when neither an
+    explicit argument nor an env override is provided.
+    """
+
+    env_value, env_raw = include_defaults_env()
+    if explicit is not None:
+        return bool(explicit), "explicit", env_raw
+    if env_value is not None:
+        return env_value, "env", env_raw
+    return True, "default", env_raw
+
+
 __all__ = [
     "truthy",
     "int_env",
@@ -93,4 +137,6 @@ __all__ = [
     "max_tool_output_env",
     "typed_results_enabled",
     "default_tool_timeout",
+    "include_defaults_env",
+    "resolve_include_defaults",
 ]

--- a/tests/integration/inspect_agents/test_iterative_truncation_param.py
+++ b/tests/integration/inspect_agents/test_iterative_truncation_param.py
@@ -8,6 +8,7 @@ from inspect_ai.tool._tool_def import ToolDef
 from inspect_ai.tool._tool_params import ToolParams
 
 from inspect_agents.iterative import build_iterative_agent
+from inspect_agents.tools import read_file
 
 pytestmark = pytest.mark.truncation
 
@@ -78,3 +79,95 @@ def test_iterative_param_caps_tool_output(monkeypatch):
     end = text.index("<END_TOOL_OUTPUT>")
     payload = text[start:end].strip("\n")
     assert len(payload.encode("utf-8")) == 4096
+
+
+@pytest.mark.parametrize(
+    ("include_defaults", "tool_factory", "expected_count"),
+    [
+        (True, lambda: [], 0),
+        (False, lambda: [read_file()], 1),
+    ],
+)
+def test_iterative_emits_defaults_telemetry(monkeypatch, include_defaults, tool_factory, expected_count):
+    events: list[dict[str, object]] = []
+
+    def _capture(name, phase, args=None, extra=None, t0=None):
+        events.append({"name": name, "phase": phase, "args": args, "extra": extra})
+        return 0.0 if t0 is None else t0
+
+    monkeypatch.setattr("inspect_agents.observability.log_tool_event", _capture)
+
+    build_iterative_agent(
+        prompt="Instrument defaults",
+        tools=tool_factory(),
+        include_defaults=include_defaults,
+        max_steps=1,
+    )
+
+    telemetry = [ev for ev in events if ev["name"] == "agent_defaults"]
+    assert telemetry, "expected agent_defaults telemetry"
+
+    record = telemetry[-1]
+    extra = record["extra"] or {}
+    assert extra["builder"] == "iterative"
+    assert extra["include_defaults"] is include_defaults
+    assert extra["include_defaults_source"] == "explicit"
+    assert extra["caller_supplied_tool_count"] == expected_count
+    assert extra["caller_supplied_replacements"] is bool(expected_count)
+    assert extra["feature_flag"] == "INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS"
+    assert extra["feature_flag_state"] == "unset"
+    assert extra["active_tool_count"] >= expected_count
+    assert isinstance(extra.get("code_only"), bool)
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected_default"),
+    [
+        ("0", False),
+        ("1", True),
+    ],
+)
+def test_iterative_include_defaults_env(monkeypatch, env_value, expected_default):
+    events: list[dict[str, object]] = []
+
+    def _capture(name, phase, args=None, extra=None, t0=None):
+        events.append({"name": name, "phase": phase, "args": args, "extra": extra})
+        return 0.0 if t0 is None else t0
+
+    monkeypatch.setattr("inspect_agents.observability.log_tool_event", _capture)
+    monkeypatch.setenv("INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS", env_value)
+
+    build_iterative_agent(prompt="Env override", tools=[], max_steps=1)
+
+    telemetry = [ev for ev in events if ev["name"] == "agent_defaults"]
+    assert telemetry, "expected agent_defaults telemetry"
+
+    record = telemetry[-1]
+    extra = record["extra"] or {}
+    assert extra["builder"] == "iterative"
+    assert extra["include_defaults"] is expected_default
+    assert extra["include_defaults_source"] == "env"
+    assert extra["feature_flag_state"] == env_value
+    assert extra["active_tool_count"] >= (1 if expected_default else 0)
+
+
+def test_iterative_include_defaults_env_can_be_overridden(monkeypatch):
+    events: list[dict[str, object]] = []
+
+    def _capture(name, phase, args=None, extra=None, t0=None):
+        events.append({"name": name, "phase": phase, "args": args, "extra": extra})
+        return 0.0 if t0 is None else t0
+
+    monkeypatch.setattr("inspect_agents.observability.log_tool_event", _capture)
+    monkeypatch.setenv("INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS", "0")
+
+    build_iterative_agent(prompt="Explicit", include_defaults=True, max_steps=1)
+
+    telemetry = [ev for ev in events if ev["name"] == "agent_defaults"]
+    assert telemetry, "expected agent_defaults telemetry"
+
+    record = telemetry[-1]
+    extra = record["extra"] or {}
+    assert extra["include_defaults"] is True
+    assert extra["include_defaults_source"] == "explicit"
+    assert extra["feature_flag_state"] == "0"

--- a/tests/integration/inspect_agents/test_research_example.py
+++ b/tests/integration/inspect_agents/test_research_example.py
@@ -39,6 +39,17 @@ def test_research_example_offline_smoke(monkeypatch, tmp_path):
     # Write logs to a temp dir (offline is enforced by the root env guard)
     monkeypatch.setenv("INSPECT_LOG_DIR", str(tmp_path))
 
+    import inspect_agents.observability as observability
+
+    captured_events: list[dict[str, object]] = []
+    original_log_tool_event = observability.log_tool_event
+
+    def _capture(name, phase, args=None, extra=None, t0=None):
+        captured_events.append({"name": name, "phase": phase, "extra": extra})
+        return original_log_tool_event(name, phase, args=args, extra=extra, t0=t0)
+
+    monkeypatch.setattr(observability, "log_tool_event", _capture)
+
     # Root autouse fixture handles environment hardening (approvals cleared,
     # optional tools disabled, provider keys unset, and NO_NETWORK=1).
 
@@ -78,3 +89,8 @@ def test_research_example_offline_smoke(monkeypatch, tmp_path):
     # Transcript assertions
     path = write_transcript()
     assert os.path.exists(path)
+    defaults_events = [ev for ev in captured_events if ev["name"] == "agent_defaults"]
+    assert defaults_events, "expected agent_defaults telemetry"
+    assert any(ev.get("extra", {}).get("builder") == "supervisor" for ev in defaults_events)
+    assert any(ev.get("extra", {}).get("include_defaults") is True for ev in defaults_events)
+    assert any(ev.get("extra", {}).get("include_defaults_source") == "default" for ev in defaults_events)

--- a/tests/integration/inspect_agents/test_supervisor.py
+++ b/tests/integration/inspect_agents/test_supervisor.py
@@ -1,10 +1,12 @@
 import asyncio
 
+import pytest
 from inspect_ai.agent._agent import AgentState, agent
 from inspect_ai.model._chat_message import ChatMessageAssistant, ChatMessageUser
 from inspect_ai.tool._tool_call import ToolCall
 
 from inspect_agents.agents import build_supervisor
+from inspect_agents.tools import read_file
 
 
 @agent
@@ -32,3 +34,90 @@ def test_supervisor_runs_and_submits():
 
     # Completion should include the submitted answer
     assert "DONE" in (result.output.completion or "")
+
+
+@pytest.mark.parametrize(
+    ("include_defaults", "tool_factory", "expected_count"),
+    [
+        (True, lambda: [], 0),
+        (False, lambda: [read_file()], 1),
+    ],
+)
+def test_supervisor_emits_defaults_telemetry(monkeypatch, include_defaults, tool_factory, expected_count):
+    events: list[dict[str, object]] = []
+
+    def _capture(name, phase, args=None, extra=None, t0=None):
+        events.append({"name": name, "phase": phase, "args": args, "extra": extra})
+        return 0.0 if t0 is None else t0
+
+    monkeypatch.setattr("inspect_agents.observability.log_tool_event", _capture)
+
+    build_supervisor(prompt="You are helpful.", tools=tool_factory(), include_defaults=include_defaults)
+
+    telemetry = [ev for ev in events if ev["name"] == "agent_defaults"]
+    assert telemetry, "expected agent_defaults telemetry"
+
+    record = telemetry[-1]
+    extra = record["extra"] or {}
+    assert extra["builder"] == "supervisor"
+    assert extra["include_defaults"] is include_defaults
+    assert extra["include_defaults_source"] == "explicit"
+    assert extra["caller_supplied_tool_count"] == expected_count
+    assert extra["caller_supplied_replacements"] is bool(expected_count)
+    assert extra["feature_flag"] == "INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS"
+    assert extra["feature_flag_state"] == "unset"
+    assert extra["active_tool_count"] >= expected_count
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected_default"),
+    [
+        ("0", False),
+        ("1", True),
+        ("no", False),
+    ],
+)
+def test_supervisor_include_defaults_env(monkeypatch, env_value, expected_default):
+    events: list[dict[str, object]] = []
+
+    def _capture(name, phase, args=None, extra=None, t0=None):
+        events.append({"name": name, "phase": phase, "args": args, "extra": extra})
+        return 0.0 if t0 is None else t0
+
+    monkeypatch.setattr("inspect_agents.observability.log_tool_event", _capture)
+    monkeypatch.setenv("INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS", env_value)
+
+    build_supervisor(prompt="You are helpful.")
+
+    telemetry = [ev for ev in events if ev["name"] == "agent_defaults"]
+    assert telemetry, "expected agent_defaults telemetry"
+
+    record = telemetry[-1]
+    extra = record["extra"] or {}
+    assert extra["builder"] == "supervisor"
+    assert extra["include_defaults"] is expected_default
+    assert extra["include_defaults_source"] == "env"
+    assert extra["feature_flag_state"] == env_value
+    assert extra["active_tool_count"] >= (1 if expected_default else 0)
+
+
+def test_supervisor_include_defaults_env_can_be_overridden(monkeypatch):
+    events: list[dict[str, object]] = []
+
+    def _capture(name, phase, args=None, extra=None, t0=None):
+        events.append({"name": name, "phase": phase, "args": args, "extra": extra})
+        return 0.0 if t0 is None else t0
+
+    monkeypatch.setattr("inspect_agents.observability.log_tool_event", _capture)
+    monkeypatch.setenv("INSPECT_AGENTS_INCLUDE_DEFAULT_TOOLS", "0")
+
+    build_supervisor(prompt="Explicit wins", include_defaults=True)
+
+    telemetry = [ev for ev in events if ev["name"] == "agent_defaults"]
+    assert telemetry, "expected agent_defaults telemetry"
+
+    record = telemetry[-1]
+    extra = record["extra"] or {}
+    assert extra["include_defaults"] is True
+    assert extra["include_defaults_source"] == "explicit"
+    assert extra["feature_flag_state"] == "0"


### PR DESCRIPTION
## What & Why

  Allow environment toggles to govern whether built-in tools are injected while emitting telemetry so we can track opt-outs. Fixes #<issue> (replace with real
  ticket).

  Scope
  Only touches include-default resolution, telemetry reporting, tests, and docs; no runner or tooling changes.

  ## Changes

  - add resolve_include_defaults/include_defaults_env helpers and call them from supervisors, iterative agent, migration shim, and config loader
  - enrich agent_defaults telemetry with flag state and source metadata
  - extend integration tests to cover explicit/env/override scenarios and annotate research smoke logs
  - document the new telemetry and env toggle in docs/how-to/operations_logging_tracing.md

  Affected areas
  src/inspect_agents/{settings,observability,agents,iterative,migration,config}.py; tests/integration/inspect_agents; docs/how-to/operations_logging_tracing.md

  ## Risk & Rollback

  Risk checklist

  - [ ] Breaking change (compat plan described)
  - [ ] Data migration/backfill (plan + window)
  - [ ] Security/privacy change (perms/secrets/PII)
  - [ ] Performance impact (baseline vs. new)
  - [x] Observability updated (metrics/logs/alerts)
  - [ ] Feature flag (name, rollout, kill-switch tested)

  Rollback
  git revert 1272c69 2239109 b8f8368 then redeploy, or re-run the previous build.

  ## Test Plan

  Automated

  - Unit: n/a (integration focus)
  - Integration/E2E: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai uv run --no_workspace pytest -q tests/integration/inspect_agents/test_supervisor.py tests/
  integration/inspect_agents/test_research_example.py tests/integration/inspect_agents/test_iterative_truncation_param.py

  Manual / Evidence

  - Steps + expected signals: observe agent_defaults tool_event in research smoke transcript showing include_defaults_source="default"
  - UI: not applicable
  - Performance: not applicable

  ## Follow-ups (optional)

  - Consider centralizing documentation in environment reference once other teams adopt the flag