### PR TITLE
feat(vending_bench): add harness runtime and integration tests

### DIFF
--- a/examples/vending_bench/memory.py
+++ b/examples/vending_bench/memory.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
+from .runtime import get_env, get_memory_store, increment_tool_count
+
 if TYPE_CHECKING:
     from inspect_ai.tool._tool import Tool
 
@@ -139,6 +141,9 @@ def _log_memory_event(
     if phase == "end" and t0:
         log_data["duration_ms"] = (time.time() - t0) * 1000
 
+    if phase == "start":
+        increment_tool_count(f"memory:{name}")
+
     logger.info(f"Memory tool event: {json.dumps(log_data)}")
     return t0 if phase == "start" else time.time()
 
@@ -147,13 +152,18 @@ def scratchpad_append() -> Tool:
     """Append entry to scratchpad memory."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="scratchpad_append")
     def scratchpad_append_impl(
         content: str, tags: list[str] = None, metadata: dict[str, Any] = None
     ) -> ScratchpadResult:
-        """Append entry to scratchpad for daily notes and observations."""
+        """Append entry to scratchpad for daily notes and observations.
+
+        Args:
+            content: Text content to store in scratchpad
+            tags: Optional list of tags for categorization
+            metadata: Optional metadata dictionary
+        """
 
         tags = tags or []
         metadata = metadata or {}
@@ -163,14 +173,11 @@ def scratchpad_append() -> Tool:
         )
 
         try:
-            memory_store = store_as(MemoryStore, instance="vending_memory")
+            memory_store = get_memory_store()
 
             # Get current environment day for context
             try:
-                from .env import VendingEnv
-
-                env = store_as(VendingEnv, instance="vending_env")
-                current_day = env.state.day
+                current_day = get_env().state.day
             except Exception:
                 current_day = 0
 
@@ -207,11 +214,16 @@ def scratchpad_read() -> Tool:
     """Read entries from scratchpad memory."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="scratchpad_read")
     def scratchpad_read_impl(limit: int = 50, tags: list[str] = None, days_back: int = 7) -> ScratchpadResult:
-        """Read entries from scratchpad with filtering by tags and time."""
+        """Read entries from scratchpad with filtering by tags and time.
+
+        Args:
+            limit: Maximum number of entries to return
+            tags: Optional list of tags to filter by
+            days_back: Number of days back to look for entries
+        """
 
         tags = tags or []
 
@@ -220,14 +232,11 @@ def scratchpad_read() -> Tool:
         )
 
         try:
-            memory_store = store_as(MemoryStore, instance="vending_memory")
+            memory_store = get_memory_store()
 
             # Get current day for filtering
             try:
-                from .env import VendingEnv
-
-                env = store_as(VendingEnv, instance="vending_env")
-                current_day = env.state.day
+                current_day = get_env().state.day
             except Exception:
                 current_day = 999999  # If no env, return all
 
@@ -270,11 +279,16 @@ def kv_set() -> Tool:
     """Set key-value data in memory store."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="kv_set")
     def kv_set_impl(key: str, value: Any, ttl_days: int = 30) -> KeyValueResult:
-        """Store key-value data with expiration for supplier info and notes."""
+        """Store key-value data with expiration for supplier info and notes.
+
+        Args:
+            key: Storage key (max 100 chars)
+            value: Value to store
+            ttl_days: Time to live in days before expiration
+        """
 
         if not key.strip():
             raise ValueError("Key cannot be empty")
@@ -285,7 +299,7 @@ def kv_set() -> Tool:
         t0 = _log_memory_event(name="kv_set", phase="start", args={"key": key, "ttl_days": ttl_days})
 
         try:
-            memory_store = store_as(MemoryStore, instance="vending_memory")
+            memory_store = get_memory_store()
             memory_store._cleanup_expired_kv()
 
             memory_store.key_value[key] = {"value": value, "timestamp": time.time(), "ttl_days": ttl_days}
@@ -309,16 +323,19 @@ def kv_get() -> Tool:
     """Get key-value data from memory store."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="kv_get")
     def kv_get_impl(key: str) -> KeyValueResult:
-        """Retrieve value by key from memory store."""
+        """Retrieve value by key from memory store.
+
+        Args:
+            key: Storage key to retrieve
+        """
 
         t0 = _log_memory_event(name="kv_get", phase="start", args={"key": key})
 
         try:
-            memory_store = store_as(MemoryStore, instance="vending_memory")
+            memory_store = get_memory_store()
             memory_store._cleanup_expired_kv()
 
             data = memory_store.key_value.get(key)
@@ -342,16 +359,20 @@ def kv_list() -> Tool:
     """List keys in memory store."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="kv_list")
     def kv_list_impl(prefix: str = "", limit: int = 100) -> KeyValueResult:
-        """List all keys in memory store with optional prefix filter."""
+        """List all keys in memory store with optional prefix filter.
+
+        Args:
+            prefix: Optional prefix to filter keys by
+            limit: Maximum number of keys to return
+        """
 
         t0 = _log_memory_event(name="kv_list", phase="start", args={"prefix": prefix, "limit": limit})
 
         try:
-            memory_store = store_as(MemoryStore, instance="vending_memory")
+            memory_store = get_memory_store()
             memory_store._cleanup_expired_kv()
 
             keys = list(memory_store.key_value.keys())
@@ -383,18 +404,22 @@ def vector_store() -> Tool:
     """Store content in vector database for semantic search."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="vector_store")
     def vector_store_impl(content: str, metadata: dict[str, Any] = None) -> VectorResult:
-        """Store content in vector database for later semantic search."""
+        """Store content in vector database for later semantic search.
+
+        Args:
+            content: Text content to store
+            metadata: Optional metadata dictionary
+        """
 
         metadata = metadata or {}
 
         t0 = _log_memory_event(name="vector_store", phase="start", args={"content_length": len(content)})
 
         try:
-            memory_store = store_as(MemoryStore, instance="vending_memory")
+            memory_store = get_memory_store()
 
             entry = VectorEntry(
                 id=memory_store._generate_id(), content=content, metadata=metadata, timestamp=time.time()
@@ -424,11 +449,16 @@ def vector_search() -> Tool:
     """Search vector database for similar content."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="vector_search")
     def vector_search_impl(query: str, limit: int = 10, similarity_threshold: float = 0.7) -> VectorResult:
-        """Search vector database for semantically similar content."""
+        """Search vector database for semantically similar content.
+
+        Args:
+            query: Search query text
+            limit: Maximum number of results to return
+            similarity_threshold: Minimum similarity score (0.0-1.0)
+        """
 
         if similarity_threshold < 0.0 or similarity_threshold > 1.0:
             raise ValueError("similarity_threshold must be between 0.0 and 1.0")
@@ -440,7 +470,7 @@ def vector_search() -> Tool:
         )
 
         try:
-            memory_store = store_as(MemoryStore, instance="vending_memory")
+            memory_store = get_memory_store()
 
             # Calculate similarities and filter
             scored_entries = []

--- a/examples/vending_bench/metrics.py
+++ b/examples/vending_bench/metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .runtime import get_tool_counts
 from .state import DailyReport, DemandProfile, SimulatorState
 
 
@@ -30,3 +31,32 @@ def daily_report(state: SimulatorState) -> DailyReport | None:
     if not state.daily_reports:
         return None
     return state.daily_reports[-1]
+
+
+class EpisodeMetrics(dict):
+    """Container for harness metrics with convenience accessors."""
+
+    def summary(self) -> dict[str, float | int]:
+        return {"net_worth": self.get("net_worth", 0.0), "units_sold": self.get("units_sold", 0)}
+
+
+def collect_episode_metrics(state: SimulatorState) -> EpisodeMetrics:
+    """Aggregate key metrics and tool usage for the current run."""
+
+    metrics = EpisodeMetrics(
+        net_worth=compute_net_worth(state),
+        units_sold=cumulative_units_sold(state),
+        day=state.day,
+        bankrupt=state.bankrupt,
+        telemetry=dict(state.telemetry),
+    )
+    metrics["tool_counts"] = get_tool_counts()
+    if state.daily_reports:
+        latest = state.daily_reports[-1]
+        metrics["last_daily_report"] = {
+            "day": latest.day,
+            "revenue": latest.revenue,
+            "cash_balance": latest.cash_balance,
+            "cash_in_machine": latest.cash_in_machine,
+        }
+    return metrics

--- a/examples/vending_bench/prompts.py
+++ b/examples/vending_bench/prompts.py
@@ -1,0 +1,39 @@
+"""Prompt templates for the vending bench supervisor and sub-agents."""
+
+SUPERVISOR_PROMPT = """
+You are the CEO of a small vending-machine company. Each simulated day you must:
+
+1. Review the daily summary email and capture insights in memory.
+2. Check inventory, orders, and cash to ensure solvency and stock levels.
+3. Plan the day's actions, delegating mechanical tasks via the physical agent.
+4. Decide on research, supplier outreach, pricing, ordering, and finance tasks.
+
+Ground rules:
+- Stay profitable and keep at least three days of cash buffer after fees.
+- Maintain product variety; avoid stockouts by ordering ahead of demand.
+- Summarise each day into the scratchpad with key metrics and decisions.
+- Persist supplier data and contracts in the key-value store.
+- Use the vector store to index important emails and summaries for recall.
+- Delegate restocking, price changes, and cash collection to the physical agent using `transfer_to_vending`.
+- Respect Inspect limits: minimise total messages, tokens, and tool calls.
+- When waiting for the next day, ensure outstanding actions are complete and document expectations.
+- If bank balance is critical or bankruptcy occurs, immediately summarise and stop.
+
+Respond with structured plans, citing tool results and memory references.
+""".strip()
+
+
+PHYSICAL_AGENT_PROMPT = """
+You are the vending-machine operations specialist.
+
+Responsibilities:
+- Restock the machine from storage based on instructions.
+- Update product prices per direction; keep prices positive and realistic.
+- Collect machine cash when asked and report the amount gathered.
+- Re-check machine inventory to confirm actions succeeded.
+
+Execution principles:
+- Ask clarifying questions only when required for safety.
+- Keep responses concise; report actions, results, and remaining inventory.
+- Stop immediately if you encounter an error and summarise what happened.
+""".strip()

--- a/examples/vending_bench/run.py
+++ b/examples/vending_bench/run.py
@@ -1,0 +1,155 @@
+"""Evaluation harness for the Vending-Bench supervisor + sub-agent stack."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+# Inspect limits
+from inspect_ai.util._limit import message_limit, time_limit, token_limit
+
+from inspect_agents.agents import build_subagents, build_supervisor
+from inspect_agents.model import resolve_model
+from inspect_agents.run import run_agent
+
+from .. import _utils
+from .config import EnvConfig
+from .env import VendingEnv
+from .memory import MemoryStore, memory_tools
+from .metrics import collect_episode_metrics
+from .prompts import PHYSICAL_AGENT_PROMPT, SUPERVISOR_PROMPT
+from .runtime import clear_runtime_context, set_runtime_context
+from .tools import physical_agent_tools, supervisor_tools
+
+
+def _tool_names(tools: list[Any]) -> list[str]:
+    names: list[str] = []
+    try:
+        from inspect_ai.tool._tool_def import ToolDef  # type: ignore
+
+        for tool in tools:
+            try:
+                names.append(ToolDef(tool).name)
+            except Exception:
+                names.append(getattr(tool, "name", getattr(tool, "__name__", "unknown_tool")))
+    except Exception:
+        for tool in tools:
+            names.append(getattr(tool, "name", getattr(tool, "__name__", "unknown_tool")))
+    return names
+
+
+def build_supervisor_agent(model: str, *, include_defaults: bool = False) -> Any:
+    """Construct the supervisor with required tools and sub-agent handoff."""
+
+    physical_tools = physical_agent_tools()
+    subagent_configs = [
+        {
+            "name": "vending",
+            "description": "Physical operations specialist for restocking, pricing, and cash collection.",
+            "prompt": PHYSICAL_AGENT_PROMPT,
+            "tools": _tool_names(physical_tools),
+            "limits": [message_limit(16), token_limit(6000)],
+        }
+    ]
+    subagents = build_subagents(
+        configs=subagent_configs,
+        base_tools=physical_tools,
+        default_model=model,
+    )
+
+    supervisor_toolset = supervisor_tools() + memory_tools() + subagents
+
+    return build_supervisor(
+        prompt=SUPERVISOR_PROMPT,
+        tools=supervisor_toolset,
+        include_defaults=include_defaults,
+        attempts=1,
+        model=model,
+        truncation="auto",
+    )
+
+
+def build_limits(config: EnvConfig) -> list[Any]:
+    """Create Inspect runtime limits for the harness run."""
+
+    return [
+        time_limit(600),  # 10 minutes wall clock per episode
+        message_limit(config.max_turns),
+        token_limit(200_000),
+    ]
+
+
+async def _run_agent(agent: Any, user_input: str, limits: list[Any]) -> Any:
+    return await run_agent(agent=agent, input=user_input, limits=limits, raise_on_limit=True)
+
+
+def _summarise_state(state: Any) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    output = getattr(state, "output", None)
+    completion = getattr(output, "completion", None)
+    if completion:
+        summary["completion"] = completion
+    messages = getattr(state, "messages", None)
+    if messages is not None:
+        try:
+            summary["message_count"] = len(messages)
+        except Exception:
+            pass
+    return summary
+
+
+def run_episode(seed: int, model: str, *, include_defaults: bool = False) -> dict[str, Any]:
+    config = EnvConfig(seed=seed)
+    env = VendingEnv(config)
+    memory = MemoryStore()
+
+    set_runtime_context(env=env, memory=memory)
+    try:
+        agent = build_supervisor_agent(model, include_defaults=include_defaults)
+        user_input = "Manage the vending machine business for the day."
+        state = asyncio.run(_run_agent(agent, user_input, build_limits(config)))
+    finally:
+        clear_runtime_context()
+
+    env.state.telemetry["seed"] = seed
+
+    metrics = collect_episode_metrics(env.state)
+    metrics["conversation"] = _summarise_state(state)
+    metrics["config"] = {
+        "seed": seed,
+        "model": model,
+        "include_defaults": include_defaults,
+    }
+    return metrics
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run the Vending-Bench harness")
+    parser.add_argument("--seed", type=int, default=42, help="Deterministic seed for the simulator")
+    _utils.add_common_model_flags(parser)
+    _utils.add_common_tool_flags(parser)
+    parser.add_argument("--output", type=Path, help="Optional path to write JSON metrics")
+    parser.add_argument(
+        "--include-default-tools", action="store_true", help="Inject inspect_agents default tool preset"
+    )
+    args = parser.parse_args()
+
+    _utils.apply_tool_env_from_args(args)
+    _utils.ensure_repo_src_on_path()
+    _utils.load_env_files(Path(__file__).parent, include_template=True)
+
+    model_id = resolve_model(provider=args.provider, model=args.model)
+    metrics = run_episode(seed=args.seed, model=model_id, include_defaults=args.include_default_tools)
+
+    output = json.dumps(metrics, indent=2)
+    if args.output:
+        args.output.write_text(output)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/vending_bench/runtime.py
+++ b/examples/vending_bench/runtime.py
@@ -1,0 +1,77 @@
+"""Runtime context helpers for the vending bench harness.
+
+These helpers provide per-run access to the simulator environment and
+memory store via context variables so that Inspect tool invocations can
+share mutable state without relying on Inspect's StoreModel wiring.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from contextvars import ContextVar
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import-time guard only
+    from .env import VendingEnv
+    from .memory import MemoryStore
+
+
+_ENV_CTX: ContextVar[VendingEnv | None] = ContextVar("vending_bench_env", default=None)
+_MEMORY_CTX: ContextVar[MemoryStore | None] = ContextVar("vending_bench_memory", default=None)
+_TOOL_COUNTER_CTX: ContextVar[Counter[str] | None] = ContextVar("vending_bench_tool_counts", default=None)
+
+
+def set_runtime_context(*, env: VendingEnv, memory: MemoryStore) -> None:
+    """Bind the active environment and memory store for the current run."""
+
+    _ENV_CTX.set(env)
+    _MEMORY_CTX.set(memory)
+    _TOOL_COUNTER_CTX.set(Counter())
+
+
+def clear_runtime_context() -> None:
+    """Clear runtime bindings (best-effort)."""
+
+    _ENV_CTX.set(None)
+    _MEMORY_CTX.set(None)
+    _TOOL_COUNTER_CTX.set(None)
+
+
+def get_env() -> VendingEnv:
+    """Return the active environment instance or raise if unset."""
+
+    env = _ENV_CTX.get(None)
+    if env is None:
+        raise RuntimeError("Vending environment is not initialised for this run")
+    return env
+
+
+def increment_tool_count(name: str) -> None:
+    """Record a tool invocation for observability metrics."""
+
+    counter = _TOOL_COUNTER_CTX.get(None)
+    if counter is None:
+        counter = Counter()
+        _TOOL_COUNTER_CTX.set(counter)
+    counter[name] += 1
+
+
+def get_tool_counts() -> dict[str, int]:
+    """Return aggregated tool invocation counts for the active run."""
+
+    counter = _TOOL_COUNTER_CTX.get(None)
+    if counter is None:
+        return {}
+    return dict(counter)
+
+
+def get_memory_store() -> MemoryStore:
+    """Return the active memory store, creating one on demand."""
+
+    memory = _MEMORY_CTX.get(None)
+    if memory is None:
+        from .memory import MemoryStore  # Local import to avoid circular import
+
+        memory = MemoryStore()
+        _MEMORY_CTX.set(memory)
+    return memory

--- a/examples/vending_bench/state.py
+++ b/examples/vending_bench/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 MINUTES_PER_DAY = 24 * 60
 
@@ -67,6 +68,7 @@ class DailyReport:
 
 @dataclass
 class SimulatorState:
+    telemetry: dict[str, Any] = field(default_factory=dict)
     day: int = 0
     minute: int = 0
     turns: int = 0

--- a/examples/vending_bench/tools.py
+++ b/examples/vending_bench/tools.py
@@ -12,10 +12,10 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
+from .runtime import get_env, increment_tool_count
+
 if TYPE_CHECKING:
     from inspect_ai.tool._tool import Tool
-
-from .env import VendingEnv
 
 
 class BaseToolParams(BaseModel):
@@ -125,6 +125,9 @@ def _log_tool_event(
     if phase == "end" and t0:
         log_data["duration_ms"] = (time.time() - t0) * 1000
 
+    if phase == "start":
+        increment_tool_count(name)
+
     logger.info(f"Tool event: {json.dumps(log_data)}")
     return t0 if phase == "start" else time.time()
 
@@ -133,17 +136,20 @@ def check_email() -> Tool:
     """Check inbox and outbox for new emails."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="check_email")
     def check_email_impl(max_emails: int = 10) -> EmailCheckResult:
-        """Check inbox and outbox for emails with daily summaries and order confirmations."""
+        """Check inbox and outbox for emails with daily summaries and order confirmations.
+
+        Args:
+            max_emails: Maximum number of emails to retrieve from each box
+        """
 
         t0 = _log_tool_event(name="check_email", phase="start", args={"max_emails": max_emails})
 
         try:
             # Get environment from store
-            env = store_as(VendingEnv, instance="vending_env")
+            env = get_env()
 
             inbox_messages = []
             for msg in env.state.inbox[-max_emails:]:
@@ -198,11 +204,14 @@ def check_inventory() -> Tool:
     """Check storage or machine inventory levels."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="check_inventory")
     def check_inventory_impl(location: str) -> InventoryCheckResult:
-        """Check current inventory levels in storage or vending machine."""
+        """Check current inventory levels in storage or vending machine.
+
+        Args:
+            location: Either 'storage' or 'machine' to specify which inventory to check
+        """
 
         if location not in ["storage", "machine"]:
             raise ValueError("location must be 'storage' or 'machine'")
@@ -210,7 +219,7 @@ def check_inventory() -> Tool:
         t0 = _log_tool_event(name="check_inventory", phase="start", args={"location": location})
 
         try:
-            env = store_as(VendingEnv, instance="vending_env")
+            env = get_env()
 
             if location == "storage":
                 inventory = dict(env.state.storage_inventory)
@@ -238,18 +247,21 @@ def check_financial_status() -> Tool:
     """Check current financial status including cash and net worth."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="check_financial_status")
     def check_financial_status_impl(include_projections: bool = False) -> FinancialStatusResult:
-        """Check current cash balance, net worth, and bankruptcy risk."""
+        """Check current cash balance, net worth, and bankruptcy risk.
+
+        Args:
+            include_projections: Whether to include financial projections in the result
+        """
 
         t0 = _log_tool_event(
             name="check_financial_status", phase="start", args={"include_projections": include_projections}
         )
 
         try:
-            env = store_as(VendingEnv, instance="vending_env")
+            env = get_env()
             summary = env.summary()
 
             # Check bankruptcy risk (less than 2 days of fees)
@@ -283,13 +295,17 @@ def restock_machine() -> Tool:
     """Restock vending machine from storage inventory."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     from inspect_agents.exceptions import ToolException
 
     @tool(name="restock_machine")
     def restock_machine_impl(sku: str, quantity: int) -> RestockMachineResult:
-        """Restock vending machine from storage inventory."""
+        """Restock vending machine from storage inventory.
+
+        Args:
+            sku: Product SKU to restock
+            quantity: Number of units to restock
+        """
 
         if quantity <= 0:
             raise ValueError("quantity must be positive")
@@ -297,7 +313,7 @@ def restock_machine() -> Tool:
         t0 = _log_tool_event(name="restock_machine", phase="start", args={"sku": sku, "quantity": quantity})
 
         try:
-            env = store_as(VendingEnv, instance="vending_env")
+            env = get_env()
 
             # Check storage availability before restocking
             available = env.state.storage_inventory.get(sku, 0)
@@ -336,13 +352,17 @@ def set_price() -> Tool:
     """Set the price for a product."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     from inspect_agents.exceptions import ToolException
 
     @tool(name="set_price")
     def set_price_impl(sku: str, price: float) -> SetPriceResult:
-        """Set the selling price for a product."""
+        """Set the selling price for a product.
+
+        Args:
+            sku: Product SKU to update
+            price: New selling price (must be positive)
+        """
 
         if price <= 0:
             raise ValueError("price must be positive")
@@ -350,7 +370,7 @@ def set_price() -> Tool:
         t0 = _log_tool_event(name="set_price", phase="start", args={"sku": sku, "price": price})
 
         try:
-            env = store_as(VendingEnv, instance="vending_env")
+            env = get_env()
 
             # Get old price
             old_price = env.state.prices.get(sku, env.state.demand_profiles[sku].product.base_price)
@@ -379,13 +399,17 @@ def place_order() -> Tool:
     """Place an order with suppliers for inventory."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     from inspect_agents.exceptions import ToolException
 
     @tool(name="place_order")
     def place_order_impl(sku: str, quantity: int) -> PlaceOrderResult:
-        """Place supplier order for inventory with automatic cost deduction."""
+        """Place supplier order for inventory with automatic cost deduction.
+
+        Args:
+            sku: Product SKU to order
+            quantity: Number of units to order
+        """
 
         if quantity <= 0:
             raise ValueError("quantity must be positive")
@@ -393,7 +417,7 @@ def place_order() -> Tool:
         t0 = _log_tool_event(name="place_order", phase="start", args={"sku": sku, "quantity": quantity})
 
         try:
-            env = store_as(VendingEnv, instance="vending_env")
+            env = get_env()
 
             order = env.place_order(sku, quantity)
             env.advance_time(30)  # 30 minutes for order processing
@@ -433,7 +457,6 @@ def collect_cash() -> Tool:
     """Collect cash from the vending machine."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="collect_cash")
     def collect_cash_impl() -> CollectCashResult:
@@ -442,7 +465,7 @@ def collect_cash() -> Tool:
         t0 = _log_tool_event(name="collect_cash", phase="start")
 
         try:
-            env = store_as(VendingEnv, instance="vending_env")
+            env = get_env()
 
             amount_collected = env.collect_machine_cash()
             env.advance_time(10)  # 10 minutes for cash collection
@@ -469,7 +492,6 @@ def wait_for_next_day() -> Tool:
     """Advance to the next day and get daily report."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="wait_for_next_day")
     def wait_for_next_day_impl() -> WaitForNextDayResult:
@@ -478,7 +500,7 @@ def wait_for_next_day() -> Tool:
         t0 = _log_tool_event(name="wait_for_next_day", phase="start")
 
         try:
-            env = store_as(VendingEnv, instance="vending_env")
+            env = get_env()
 
             old_day = env.state.day
             env.end_of_day()
@@ -519,11 +541,15 @@ def ai_web_search() -> Tool:
     """Perform web search for supplier information (deterministic stub)."""
 
     from inspect_ai.tool._tool import tool
-    from inspect_ai.util._store_model import store_as
 
     @tool(name="ai_web_search")
     def ai_web_search_impl(query: str, max_results: int = 5) -> WebSearchResult:
-        """Search for supplier contacts and product information (deterministic results)."""
+        """Search for supplier contacts and product information (deterministic results).
+
+        Args:
+            query: Search query string
+            max_results: Maximum number of search results to return
+        """
 
         if max_results < 1 or max_results > 20:
             raise ValueError("max_results must be between 1 and 20")
@@ -531,7 +557,7 @@ def ai_web_search() -> Tool:
         t0 = _log_tool_event(name="ai_web_search", phase="start", args={"query": query, "max_results": max_results})
 
         try:
-            env = store_as(VendingEnv, instance="vending_env")
+            env = get_env()
             env.advance_time(60)  # 1 hour for research
 
             # Deterministic stub results based on query content

--- a/tests/integration/vending_bench/__init__.py
+++ b/tests/integration/vending_bench/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for vending bench harness."""

--- a/tests/integration/vending_bench/test_run_harness.py
+++ b/tests/integration/vending_bench/test_run_harness.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NO_NETWORK", "1")
+
+
+@pytest.fixture
+def harness_module(monkeypatch: pytest.MonkeyPatch):
+    import importlib
+    import sys
+
+    repo_root = Path(__file__).resolve().parents[3]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    module = importlib.import_module("examples.vending_bench.run")
+    return module
+
+
+def _fake_state(message_count: int = 3, completion: str = "Episode complete") -> Any:
+    return SimpleNamespace(
+        output=SimpleNamespace(completion=completion),
+        messages=[SimpleNamespace(role="user")] * message_count,
+    )
+
+
+@pytest.mark.parametrize("include_defaults", [False, True])
+def test_run_episode_collects_metrics(monkeypatch: pytest.MonkeyPatch, harness_module, include_defaults: bool) -> None:
+    records: dict[str, Any] = {}
+
+    async def fake_run_agent(agent, input, limits, raise_on_limit):  # type: ignore[no-untyped-def]
+        records["input"] = input
+        records["limits"] = limits
+        records["agent"] = agent
+        return _fake_state()
+
+    captured: dict[str, Any] = {}
+
+    def fake_build_supervisor_agent(model, include_defaults=False):  # type: ignore[no-untyped-def]
+        captured["model"] = model
+        captured["include_defaults"] = include_defaults
+        return SimpleNamespace(tag="supervisor", model=model, include_defaults=include_defaults)
+
+    monkeypatch.setattr(harness_module, "run_agent", fake_run_agent)
+    monkeypatch.setattr(harness_module, "build_supervisor_agent", fake_build_supervisor_agent)
+
+    metrics = harness_module.run_episode(seed=11, model="stub-model", include_defaults=include_defaults)
+
+    # Metrics should include config, conversation summary, and tool counts
+    assert metrics["config"]["seed"] == 11
+    assert metrics["config"]["model"] == "stub-model"
+    assert metrics["config"]["include_defaults"] is include_defaults
+    assert metrics["conversation"]["message_count"] == 3
+    assert metrics["telemetry"]["seed"] == 11
+    assert metrics["tool_counts"] == {}
+
+    # Supervisor builder invoked with forwarded arguments
+    assert captured["model"] == "stub-model"
+    assert captured["include_defaults"] is include_defaults
+
+    # Limits should include message cap from EnvConfig
+    message_limit = next(limit for limit in records["limits"] if getattr(limit, "limit", None) == 2000)
+    assert getattr(message_limit, "limit", None) == 2000
+    assert records["input"].startswith("Manage the vending machine")
+
+
+def test_cli_writes_json_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, harness_module) -> None:
+    output_path = tmp_path / "metrics.json"
+
+    monkeypatch.setattr(harness_module, "run_episode", lambda **_: {"ok": True})
+    monkeypatch.setattr(harness_module, "resolve_model", lambda provider=None, model=None: "stub-model")
+    monkeypatch.setattr(harness_module._utils, "apply_tool_env_from_args", lambda args: None)
+    monkeypatch.setattr(harness_module._utils, "ensure_repo_src_on_path", lambda *args, **kwargs: None)
+    monkeypatch.setattr(harness_module._utils, "load_env_files", lambda *args, **kwargs: None)
+
+    argv = [
+        "run.py",
+        "--seed",
+        "5",
+        "--provider",
+        "offline",
+        "--model",
+        "toy",
+        "--output",
+        str(output_path),
+    ]
+
+    monkeypatch.setattr("sys.argv", argv)
+
+    harness_module.main()
+
+    data = json.loads(output_path.read_text())
+    assert data == {"ok": True}


### PR DESCRIPTION
## What & Why

  Add a runnable Vending-Bench harness that wires the simulator, prompts, and limits together so the benchmark can execute end-to-end and emit telemetry for
  analysis.

  Scope
  Vending-Bench harness, prompts, runtime context, and integration coverage. Simulator core, docs, and mirror automation remain out of scope.

  ## Changes

  - Introduced contextvar-backed runtime state so tools and memory share the same simulator instance while counting tool usage.
  - Added supervisor and physical-agent prompts plus an evaluation runner CLI that enforces Inspect limits and captures metrics.
  - Landed integration tests that stub the run to assert config propagation and CLI output handling.

  Affected areas
  examples/vending_bench/{runtime.py,memory.py,metrics.py,state.py,tools.py,prompts.py,run.py}, tests/integration/vending_bench/

  ## Risk & Rollback

  Risk checklist

  - [ ] Breaking change (compat plan described)
  - [ ] Data migration/backfill (plan + window)
  - [ ] Security/privacy change (perms/secrets/PII)
  - [ ] Performance impact (baseline vs. new)
  - [x] Observability updated (metrics/logs/alerts)
  - [ ] Feature flag (name, rollout, kill-switch tested)

  Rollback
  Revert the three commits (d99dc4c, cc8ac1b, 3bca391) or git revert them in order; no data cleanup required.

  ## Test Plan

  Automated

  - Unit: n/a (no unit tests changed)
  - Integration/E2E: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python -m pytest -q tests/integration/vending_bench

  Manual / Evidence

  - Steps + expected signals: n/a
  - UI (if applicable): n/a
  - Performance (if applicable): n/a

  ## Follow-ups (optional)

  - Future work: document harness usage and extend coverage once additional scenarios land.
