### PR TITLE
Fix vending tool factory returns

### DIFF
--- a/examples/vending_bench/tools.py
+++ b/examples/vending_bench/tools.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 
 from .runtime import get_env, increment_tool_count
-from .state import aggregate_sku_quantities, serialize_machine_inventory, MINUTES_PER_DAY, EmailMessage
+from .state import MINUTES_PER_DAY, EmailMessage, aggregate_sku_quantities, serialize_machine_inventory
 
 if TYPE_CHECKING:
     from inspect_ai.tool._tool import Tool
@@ -428,7 +428,22 @@ def check_machine_overview() -> Tool:
             _log_tool_event(
                 name="check_machine_overview",
                 phase="end",
-                extra={"total_units": total_units, "unique_skus": unique_skus, "low_stock_count": len(low_stock_skus)},
+                extra={
+                    "total_units": total_units,
+                    "unique_skus": unique_skus,
+                    "low_stock_count": len(low_stock_skus),
+                },
+                t0=t0,
+            )
+
+            return result
+
+        except Exception as e:
+            _log_tool_event(name="check_machine_overview", phase="error", extra={"error": str(e)}, t0=t0)
+            raise
+
+    return check_machine_overview_impl
+
 
 def get_machine_inventory() -> Tool:
     """Return slot-level machine inventory snapshot."""
@@ -463,17 +478,12 @@ def get_machine_inventory() -> Tool:
                 name="get_machine_inventory",
                 phase="end",
                 extra={"total_units": total_units, "slot_count": len(slots)},
-
                 t0=t0,
             )
 
             return result
 
         except Exception as e:
-            _log_tool_event(name="check_machine_overview", phase="error", extra={"error": str(e)}, t0=t0)
-            raise
-
-    return check_machine_overview_impl
             _log_tool_event(name="get_machine_inventory", phase="error", extra={"error": str(e)}, t0=t0)
             raise
 


### PR DESCRIPTION
## What & Why

  Restore vending tool factories so supervisor and physical agents can
  instantiate without runtime errors, fixing broken runs observed in the
  local inspection.

  Scope
  Out of scope: addressing uv workspace configuration for tests.

  ## Changes

  - Added missing return statements to check_machine_overview and
    get_machine_inventory
  - Corrected error logging to use the proper tool names and preserved
    timing metadata

  Affected areas
  examples/vending_bench/tools.py

  ## Risk & Rollback

  Risk checklist

  - [ ] Breaking change (compat plan described)
  - [ ] Data migration/backfill (plan + window)
  - [ ] Security/privacy change (perms/secrets/PII)
  - [ ] Performance impact (baseline vs. new)
  - [ ] Observability updated (metrics/logs/alerts)
  - [ ] Feature flag (name, rollout, kill-switch tested)

  Rollback
  Revert commit fix(vending_bench): restore tool factory returns.

  ## Test Plan

  Automated

  - Unit: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai uv run pytest -q tests/unit/vending_bench tests/integration/vending_bench
    (fails: external/inspect_ai missing pyproject metadata)
  - Integration/E2E: not run (blocked by same uv workspace error)

  Manual / Evidence

  - Steps + expected signals: supervisor tool list builds without raising
  - UI (if applicable): not applicable
  - Performance (if applicable): not applicable

  ## Follow-ups (optional)

  - Provide minimal pyproject.toml for external/inspect_ai to unblock
    uv run pytest