### PR TITLE
feat: rebuild vending demand model with seeded linear elasticity

### DIFF
--- a/examples/vending_bench/demand.py
+++ b/examples/vending_bench/demand.py
@@ -2,12 +2,58 @@
 
 from __future__ import annotations
 
+import hashlib
 import math
 import random
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from .state import DemandProfile, Slot
+from .state import DemandProfile, Product, Slot
+
+
+@dataclass(frozen=True)
+class GeneratedDemandParameters:
+    reference_price: float
+    base_sales: float
+    elasticity: float
+
+
+PRICE_FACTOR_MIN = 0.0
+PRICE_FACTOR_MAX = 3.0
+VARIETY_TARGET = 4
+
+
+def generate_parameters(product: Product, *, seed: int | None = None) -> GeneratedDemandParameters:
+    """Deterministically generate demand parameters for a product."""
+
+    base_seed: int
+    if seed is not None:
+        base_seed = seed
+    else:
+        # Stable seed using SKU; avoid Python hash randomisation.
+        digest = hashlib.sha256(product.sku.encode("utf-8")).digest()
+        base_seed = int.from_bytes(digest[:8], "big")
+
+    rng = random.Random(base_seed)
+
+    base_price = max(0.05, product.base_price)
+    reference_price = max(0.05, rng.uniform(0.9, 1.1) * base_price)
+
+    base_demand = max(0.25, product.base_daily_demand)
+    base_sales = max(0.25, rng.uniform(0.8, 1.2) * base_demand)
+
+    elasticity_hint = product.price_elasticity if product.price_elasticity != 0 else -1.0
+    elasticity_randomiser = rng.uniform(0.85, 1.15)
+    elasticity = elasticity_hint * elasticity_randomiser
+    # Ensure we always return a negative elasticity within sane bounds
+    elasticity = -abs(elasticity)
+    elasticity = max(-3.0, min(-0.1, elasticity))
+
+    return GeneratedDemandParameters(
+        reference_price=reference_price,
+        base_sales=base_sales,
+        elasticity=elasticity,
+    )
 
 
 @dataclass
@@ -24,16 +70,43 @@ class SlotSale:
 
 
 class DemandModel:
-    def __init__(self, seed: int, skus: Iterable[str]) -> None:
+    def __init__(self, seed: int, skus: Iterable[str], profiles: dict[str, DemandProfile] | None = None) -> None:
         self._seed = seed
         self._sku_index: dict[str, int] = {sku: idx for idx, sku in enumerate(sorted(set(skus)))}
         self._weather_cache: dict[int, float] = {}
         self._noise_cache: dict[tuple[int, str], float] = {}
+        if profiles:
+            self.ensure_profiles(profiles)
 
     def _ensure_index(self, sku: str) -> int:
         if sku not in self._sku_index:
             self._sku_index[sku] = len(self._sku_index)
         return self._sku_index[sku]
+
+    def ensure_profiles(self, profiles: dict[str, DemandProfile]) -> None:
+        """Ensure demand parameters are generated for each profile."""
+
+        for sku, profile in profiles.items():
+            self._ensure_profile_parameters(sku, profile)
+
+    def _parameter_seed(self, sku: str) -> int:
+        idx = self._ensure_index(sku)
+        data = f"{self._seed}:{idx}:{sku}".encode()
+        digest = hashlib.sha256(data).digest()
+        return int.from_bytes(digest[:8], "big")
+
+    def _ensure_profile_parameters(self, sku: str, profile: DemandProfile) -> tuple[float, float, float]:
+        reference_price = profile.reference_price
+        base_sales = profile.base_daily_sales
+        elasticity = profile.price_elasticity
+        if reference_price is not None and base_sales is not None and elasticity is not None:
+            return reference_price, base_sales, elasticity
+
+        params = generate_parameters(profile.product, seed=self._parameter_seed(sku))
+        profile.reference_price = params.reference_price
+        profile.base_daily_sales = params.base_sales
+        profile.price_elasticity = params.elasticity
+        return profile.reference_price, profile.base_daily_sales, profile.price_elasticity
 
     def _weather_factor(self, day: int, sensitivity: float) -> float:
         if day not in self._weather_cache:
@@ -77,9 +150,14 @@ class DemandModel:
         unique_classes = {cls for cls in stocked_classes if cls}
         if not unique_classes:
             return 0.5  # empty machine – effectively zero demand
-        target = 4
-        deficit = max(0, target - len(unique_classes))
-        penalty = 1.0 - 0.5 * (deficit / target)
+
+        count = len(unique_classes)
+        if count <= VARIETY_TARGET:
+            return 1.0
+
+        excess = count - VARIETY_TARGET
+        ratio = excess / max(1, VARIETY_TARGET)
+        penalty = 1.0 - min(0.5, 0.5 * ratio)
         return max(0.5, penalty)
 
     def simulate_day(
@@ -92,6 +170,8 @@ class DemandModel:
         sku_slots: dict[str, list[tuple[int, int, Slot]]] = {}
         stocked_classes: list[str] = []
         for row_idx, row in enumerate(machine_inventory):
+            if not isinstance(row, list):
+                continue
             for col_idx, slot in enumerate(row):
                 if slot is None or slot.sku is None or slot.quantity <= 0:
                     continue
@@ -112,25 +192,23 @@ class DemandModel:
                 units_sold[sku] = 0
                 continue
 
-            product = profile.product
+            reference_price, base_sales, elasticity = self._ensure_profile_parameters(sku, profile)
             prices_for_sku = [slot.price for _, _, slot in slots if slot.price is not None]
-            if prices_for_sku:
-                price = min(prices_for_sku)
-            else:
-                price = product.base_price
-            base_demand = product.base_daily_demand
-            if product.base_price <= 0:
+            price = min(prices_for_sku) if prices_for_sku else reference_price
+
+            if reference_price <= 0:
                 price_factor = 1.0
             else:
-                ratio = max(0.01, price / product.base_price)
-                price_factor = ratio**product.price_elasticity
+                price_delta = (price - reference_price) / reference_price
+                price_factor = 1.0 + elasticity * price_delta
+                price_factor = max(PRICE_FACTOR_MIN, min(PRICE_FACTOR_MAX, price_factor))
 
             weekday_factor = self._weekday_multiplier(day)
             seasonal_factor = self._seasonal_multiplier(day, profile.seasonal_amplitude)
             weather_factor = self._weather_factor(day, profile.weather_sensitivity)
             noise = self._noise(day, sku, profile.noise_scale)
 
-            demand = base_demand
+            demand = base_sales
             demand *= price_factor
             demand *= weekday_factor
             demand *= seasonal_factor
@@ -149,7 +227,7 @@ class DemandModel:
                 sell_qty = min(slot.quantity, remaining)
                 if sell_qty <= 0:
                     continue
-                slot_price = slot.price if slot.price is not None else product.base_price
+                slot_price = slot.price if slot.price is not None else reference_price
                 key = (row_idx, col_idx)
                 sale = slot_sales.setdefault(key, SlotSale())
                 sale.quantity += sell_qty

--- a/examples/vending_bench/env.py
+++ b/examples/vending_bench/env.py
@@ -51,14 +51,26 @@ class VendingEnv:
         )
         self.state.reset_daily_counters()
         self._rng = random.Random(self.config.seed)
-        self._demand = DemandModel(self.config.seed + 1, self.state.demand_profiles.keys())
+        self._demand = DemandModel(
+            self.config.seed + 1,
+            self.state.demand_profiles.keys(),
+            profiles=self.state.demand_profiles,
+        )
         self._supplier = SupplierModel(self.config.seed + 2)
         self._morning_initialised = False
 
     @staticmethod
     def _clone_profiles(catalogue: dict[str, DemandProfile]) -> dict[str, DemandProfile]:
         return {
-            sku: DemandProfile(product=profile.product, noise_scale=profile.noise_scale)
+            sku: DemandProfile(
+                product=profile.product,
+                reference_price=profile.reference_price,
+                base_daily_sales=profile.base_daily_sales,
+                price_elasticity=profile.price_elasticity,
+                noise_scale=profile.noise_scale,
+                weather_sensitivity=profile.weather_sensitivity,
+                seasonal_amplitude=profile.seasonal_amplitude,
+            )
             for sku, profile in catalogue.items()
         }
 
@@ -101,7 +113,25 @@ class VendingEnv:
         self.state.reset_daily_counters()
         self._morning_initialised = True
 
+    def _update_negative_balance_days(self) -> None:
+        days = getattr(self.state, "negative_balance_days", 0)
+        if self.state.cash_balance < 0:
+            days += 1
+        else:
+            days = 0
+        self.state.negative_balance_days = days
+        if days >= 10:
+            self.state.bankrupt = True
+
+    def _normalize_machine_inventory(self) -> None:
+        inventory = self.state.machine_inventory
+        if isinstance(inventory, list) and all(isinstance(row, list) for row in inventory):
+            return
+        self.state.machine_inventory = [[None for _ in range(MACHINE_COLUMNS)] for _ in range(MACHINE_ROWS)]
+
     def _process_morning_flow(self) -> None:
+        self._normalize_machine_inventory()
+
         # Deliver orders
         delivered, pending = self._supplier.split_deliveries(self.state.outstanding_orders, self.state.day)
         self.state.outstanding_orders = pending
@@ -133,10 +163,7 @@ class VendingEnv:
         self.state.cash_in_machine += revenue
 
         self.state.cash_balance -= self.config.daily_fee
-        if self.state.cash_balance < 0:
-            self.state.bankrupt = True
-
-        self.state.cash_balance += self.collect_machine_cash()
+        self._update_negative_balance_days()
 
         report = DailyReport(
             day=self.state.day,
@@ -161,6 +188,9 @@ class VendingEnv:
     def collect_machine_cash(self) -> float:
         amount = self.state.cash_in_machine
         self.state.cash_in_machine = 0.0
+        if amount != 0.0:
+            self.state.cash_balance += amount
+            self._update_negative_balance_days()
         return amount
 
     def restock(self, sku: str, quantity: int, *, row: int, column: int) -> None:
@@ -178,12 +208,14 @@ class VendingEnv:
         if profile is None:
             raise ValueError(f"Unknown SKU {sku}")
 
+        self._demand.ensure_profiles({sku: profile})
+
         slot = self._ensure_slot(row, column)
 
         if slot.sku is None:
             slot.sku = sku
             slot.capacity = profile.product.slot_capacity
-            slot.price = profile.product.base_price
+            slot.price = profile.reference_price if profile.reference_price is not None else profile.product.base_price
         elif slot.sku != sku:
             raise ValueError(f"slot ({row}, {column}) currently holds SKU {slot.sku}")
 
@@ -228,9 +260,11 @@ class VendingEnv:
         return message
 
     def place_order(self, sku: str, quantity: int) -> Order:
-        if sku not in self.state.demand_profiles:
+        profile = self.state.demand_profiles.get(sku)
+        if profile is None:
             raise ValueError(f"Unknown SKU {sku}")
-        product = self.state.demand_profiles[sku].product
+        self._demand.ensure_profiles({sku: profile})
+        product = profile.product
         order = self._supplier.create_order(product=product, quantity=quantity, day_ordered=self.state.day)
         total_cost = order.total_cost
         if self.state.cash_balance < total_cost:

--- a/examples/vending_bench/state.py
+++ b/examples/vending_bench/state.py
@@ -52,6 +52,9 @@ class DemandProfile:
     """Runtime demand parameters for a SKU."""
 
     product: Product
+    reference_price: float | None = None
+    base_daily_sales: float | None = None
+    price_elasticity: float | None = None
     noise_scale: float = 0.08
     weather_sensitivity: float = 0.05
     seasonal_amplitude: float = 0.1
@@ -109,6 +112,7 @@ class SimulatorState:
     outbox: list[EmailMessage] = field(default_factory=list)
     units_sold_today: dict[str, int] = field(default_factory=dict)
     daily_reports: list[DailyReport] = field(default_factory=list)
+    negative_balance_days: int = 0
     bankrupt: bool = False
 
     def reset_daily_counters(self) -> None:

--- a/examples/vending_bench/tools.py
+++ b/examples/vending_bench/tools.py
@@ -605,7 +605,9 @@ def restock_machine() -> Tool:
     from inspect_ai.tool._tool import tool
 
     @tool(name="restock_machine")
-    def restock_machine_impl(sku: str | None = None, quantity: int | None = None, row: int | None = None, column: int | None = None) -> RestockMachineResult:
+    def restock_machine_impl(
+        sku: str | None = None, quantity: int | None = None, row: int | None = None, column: int | None = None
+    ) -> RestockMachineResult:
         """Restock vending machine from storage inventory.
 
         Args:
@@ -618,12 +620,19 @@ def restock_machine() -> Tool:
         validated_sku = _require_non_empty_string("sku", sku)
         validated_quantity = _require_positive_int("quantity", quantity)
         validated_row = _require_positive_int("row", row) if row is not None else _require_positive_int("row", None)
-        validated_column = _require_positive_int("column", column) if column is not None else _require_positive_int("column", None)
+        validated_column = (
+            _require_positive_int("column", column) if column is not None else _require_positive_int("column", None)
+        )
 
         t0 = _log_tool_event(
             name="restock_machine",
             phase="start",
-            args={"sku": validated_sku, "quantity": validated_quantity, "row": validated_row, "column": validated_column},
+            args={
+                "sku": validated_sku,
+                "quantity": validated_quantity,
+                "row": validated_row,
+                "column": validated_column,
+            },
         )
 
         try:
@@ -725,8 +734,11 @@ def set_price() -> Tool:
                 slot = env.state.machine_inventory[update.row][update.column]
                 if slot is None or slot.sku is None:
                     raise ToolException(f"slot ({update.row}, {update.column}) is empty")
-                product = env.state.demand_profiles[slot.sku].product
-                old_price = slot.price if slot.price is not None else product.base_price
+                profile = env.state.demand_profiles[slot.sku]
+                fallback_price = (
+                    profile.reference_price if profile.reference_price is not None else profile.product.base_price
+                )
+                old_price = slot.price if slot.price is not None else fallback_price
                 snapshot[(update.row, update.column)] = (slot.sku, old_price)
 
             env.set_price({(upd.row, upd.column): upd.price for upd in updates})
@@ -1001,6 +1013,7 @@ def ai_web_search() -> Tool:
 def supervisor_tools() -> list[Tool]:
     """Return list of tools available to the supervisor agent."""
     return [
+        check_inventory(),
         check_storage_inventory(),
         check_machine_overview(),
         read_email(),
@@ -1040,4 +1053,3 @@ def all_vending_tools() -> list[Tool]:
         ai_web_search(),
         get_machine_inventory(),
     ]
-

--- a/tests/unit/vending_bench/test_demand.py
+++ b/tests/unit/vending_bench/test_demand.py
@@ -1,0 +1,112 @@
+"""Unit tests for the vending demand model."""
+
+from __future__ import annotations
+
+import pytest
+
+from examples.vending_bench.demand import DemandModel, generate_parameters
+from examples.vending_bench.state import DemandProfile, Product, Slot
+
+
+def _build_product(*, sku: str = "test_sku") -> Product:
+    return Product(
+        sku=sku,
+        name="Test Product",
+        size="small",
+        slot_capacity=12,
+        unit_cost=1.0,
+        base_price=2.0,
+        base_daily_demand=10.0,
+        price_elasticity=-1.0,
+        variety_class="snack",
+    )
+
+
+def test_generate_parameters_deterministic():
+    product = _build_product()
+
+    params_a = generate_parameters(product, seed=1234)
+    params_b = generate_parameters(product, seed=1234)
+
+    assert params_a == params_b
+    assert params_a.reference_price > 0
+    assert params_a.base_sales > 0
+    assert params_a.elasticity < 0
+
+
+def test_ensure_profiles_populates_parameters():
+    product = _build_product(sku="profile_sku")
+    profile = DemandProfile(product=product)
+    model = DemandModel(seed=21, skus=[product.sku])
+
+    assert profile.reference_price is None
+    assert profile.base_daily_sales is None
+    assert profile.price_elasticity is None
+
+    model.ensure_profiles({product.sku: profile})
+
+    assert profile.reference_price is not None
+    assert profile.base_daily_sales is not None
+    assert profile.price_elasticity is not None
+
+    before = (
+        profile.reference_price,
+        profile.base_daily_sales,
+        profile.price_elasticity,
+    )
+
+    model.ensure_profiles({product.sku: profile})
+
+    after = (
+        profile.reference_price,
+        profile.base_daily_sales,
+        profile.price_elasticity,
+    )
+
+    assert after == before
+
+
+def test_linear_price_elasticity_response():
+    product = _build_product(sku="elastic_sku")
+    profile = DemandProfile(
+        product=product,
+        reference_price=2.0,
+        base_daily_sales=10.0,
+        price_elasticity=-1.2,
+        noise_scale=0.0,
+        weather_sensitivity=0.0,
+        seasonal_amplitude=0.0,
+    )
+    model = DemandModel(seed=7, skus=[product.sku])
+
+    def simulate(price: float) -> int:
+        machine_inventory = [[None for _ in range(3)] for _ in range(4)]
+        machine_inventory[0][0] = Slot(
+            sku=product.sku,
+            quantity=200,
+            price=price,
+            capacity=product.slot_capacity,
+        )
+        outcome = model.simulate_day(
+            day=1,
+            demand_profiles={product.sku: profile},
+            machine_inventory=machine_inventory,
+        )
+        return outcome.units_sold[product.sku]
+
+    at_reference = simulate(2.0)
+    discounted = simulate(1.8)
+    premium = simulate(2.2)
+
+    assert at_reference == 10
+    assert discounted == 11
+    assert premium == 9
+
+
+def test_variety_penalty_excess_categories():
+    penalty_low = DemandModel._variety_penalty(["snack", "beverage", "snack"])
+    penalty_high = DemandModel._variety_penalty(["snack", "beverage", "hot", "cold", "gum", "candy"])
+
+    assert penalty_low == pytest.approx(1.0)
+    assert penalty_high == pytest.approx(0.75)
+    assert 0.5 <= penalty_high < penalty_low


### PR DESCRIPTION
## What & Why

  Brings the vending demand simulation back in line with the benchmark spec by switching to a seeded linear elasticity model and wiring the simulator/tooling to use generated parameters.

  Scope
  Out of scope: revisiting broader pricing heuristics or supervisor policies.

  ## Changes

  - add deterministic parameter generation and linear price elasticity in examples/vending_bench/demand.py
  - update env lifecycle for cash handling, negative balance tracking, and seeded profile initialization
  - surface generated pricing to tools and supervisor inventory views
  - introduce targeted unit tests covering parameter generation, elasticity response, and variety penalties

  Affected areas
  examples/vending_bench/, tests/unit/vending_bench/

  ## Risk & Rollback

  Risk checklist

  - [ ] Breaking change (compat plan described)
  - [ ] Data migration/backfill (plan + window)
  - [ ] Security/privacy change (perms/secrets/PII)
  - [ ] Performance impact (baseline vs. new)
  - [ ] Observability updated (metrics/logs/alerts)
  - [ ] Feature flag (name, rollout, kill-switch tested)

  Rollback
  Revert commits 8004585 and c71f005, redeploy, and restore previous demand profile cache if persisted.

  ## Test Plan

  Automated

  - Unit: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python -m pytest -q tests/unit/vending_bench/test_demand.py
  - Unit: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python -m pytest -q tests/unit/vending_bench/test_env.py::test_morning_update_preserves_machine_cash
  - Unit: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python -m pytest -q tests/unit/vending_bench/test_env.py::test_bankruptcy_requires_grace_period
  - Integration: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python -m pytest -q tests/unit/vending_bench/test_tools.py::TestToolIntegration::test_collect_cash_transfers_machine_funds
  - Integration: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python -m pytest -q tests/unit/vending_bench/test_tools.py::TestToolCollections::test_supervisor_tools_collection

  Manual / Evidence

  - Steps + expected signals: not needed (logic-only change)

  ## Follow-ups (optional)

  - Evaluate PRICE_FACTOR_MAX and elasticity bounds against benchmark telemetry once broader simulation tuning resumes.
