### PR TITLE
fix: Correct vending slot indexing and expand clarification testsFix tool interface

### DIFF
--- a/examples/vending_bench/tools.py
+++ b/examples/vending_bench/tools.py
@@ -647,10 +647,14 @@ def restock_machine() -> Tool:
                     f"Insufficient storage inventory for {validated_sku}: have {available}, need {validated_quantity}"
                 )
 
-            env.restock(validated_sku, validated_quantity, row=validated_row, column=validated_column)
+            # Convert 1-indexed input to 0-indexed for environment
+            env_row = validated_row - 1
+            env_column = validated_column - 1
+
+            env.restock(validated_sku, validated_quantity, row=env_row, column=env_column)
             env.advance_time(75)  # 75 minutes per benchmark specification
 
-            slot = env.state.machine_inventory[validated_row][validated_column]
+            slot = env.state.machine_inventory[env_row][env_column]
             if slot is None:
                 raise ToolException(f"slot ({validated_row}, {validated_column}) unavailable after restock")
             capacity = (
@@ -731,7 +735,10 @@ def set_price() -> Tool:
 
             snapshot: dict[tuple[int, int], tuple[str, float]] = {}
             for update in updates:
-                slot = env.state.machine_inventory[update.row][update.column]
+                # Convert 1-indexed input to 0-indexed for environment
+                env_row = update.row - 1
+                env_column = update.column - 1
+                slot = env.state.machine_inventory[env_row][env_column]
                 if slot is None or slot.sku is None:
                     raise ToolException(f"slot ({update.row}, {update.column}) is empty")
                 profile = env.state.demand_profiles[slot.sku]
@@ -741,7 +748,7 @@ def set_price() -> Tool:
                 old_price = slot.price if slot.price is not None else fallback_price
                 snapshot[(update.row, update.column)] = (slot.sku, old_price)
 
-            env.set_price({(upd.row, upd.column): upd.price for upd in updates})
+            env.set_price({(upd.row - 1, upd.column - 1): upd.price for upd in updates})
             env.advance_time(300)  # 5 hours for price changes
 
             results = [

--- a/tests/integration/vending_bench/test_clarification_loop.py
+++ b/tests/integration/vending_bench/test_clarification_loop.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from examples.vending_bench.tools import SlotPriceUpdate
 from inspect_agents.exceptions import ToolException
 
 
@@ -22,13 +23,33 @@ def _no_network(monkeypatch: pytest.MonkeyPatch) -> None:
 @pytest.fixture
 def mock_env():
     """Create a mock vending environment for testing."""
+    # Create mock slots for machine inventory
+    mock_slot = SimpleNamespace(sku="chips", quantity=5, price=1.50, capacity=10)
+    machine_inventory = [[None for _ in range(3)] for _ in range(4)]
+    machine_inventory[0][0] = mock_slot  # Place chips in slot (0, 0)
+
     state = SimpleNamespace(
         storage_inventory={"chips": 50, "soda": 30, "candy": 25},
-        machine_inventory={"chips": 10, "soda": 5, "candy": 8},
+        machine_inventory=machine_inventory,
         demand_profiles={
-            "chips": SimpleNamespace(product=SimpleNamespace(base_price=1.50)),
-            "soda": SimpleNamespace(product=SimpleNamespace(base_price=2.00)),
-            "candy": SimpleNamespace(product=SimpleNamespace(base_price=1.25)),
+            "chips": SimpleNamespace(
+                product=SimpleNamespace(base_price=1.50),
+                reference_price=1.50,
+                base_daily_sales=10.0,
+                price_elasticity=-1.0,
+            ),
+            "soda": SimpleNamespace(
+                product=SimpleNamespace(base_price=2.00),
+                reference_price=2.00,
+                base_daily_sales=8.0,
+                price_elasticity=-0.8,
+            ),
+            "candy": SimpleNamespace(
+                product=SimpleNamespace(base_price=1.25),
+                reference_price=1.25,
+                base_daily_sales=12.0,
+                price_elasticity=-1.2,
+            ),
         },
         prices={"chips": 1.50, "soda": 2.00, "candy": 1.25},
     )
@@ -132,7 +153,7 @@ class TestRestockMachineClarificationLoop:
             restock_tool = vending_tools_module.restock_machine()
 
             with pytest.raises(ToolException) as exc_info:
-                restock_tool(sku=None, quantity=10)
+                restock_tool(sku=None, quantity=10, row=1, column=1)
 
             assert "sku is required to complete this action" in str(exc_info.value)
 
@@ -142,7 +163,7 @@ class TestRestockMachineClarificationLoop:
             restock_tool = vending_tools_module.restock_machine()
 
             with pytest.raises(ToolException) as exc_info:
-                restock_tool(sku="chips", quantity=None)
+                restock_tool(sku="chips", quantity=None, row=1, column=1)
 
             assert "quantity is required to complete this action" in str(exc_info.value)
 
@@ -152,11 +173,31 @@ class TestRestockMachineClarificationLoop:
             restock_tool = vending_tools_module.restock_machine()
 
             with pytest.raises(ToolException) as exc_info:
-                restock_tool(sku="chips", quantity=100)  # More than available (50)
+                restock_tool(sku="chips", quantity=100, row=1, column=1)  # More than available (50)
 
             error_msg = str(exc_info.value)
             assert "Insufficient storage inventory for chips" in error_msg
             assert "have 50, need 100" in error_msg
+
+    def test_restock_missing_row_triggers_exception(self, vending_tools_module, mock_env):
+        """Test that missing row in restock triggers ToolException."""
+        with patch("examples.vending_bench.tools.get_env", return_value=mock_env):
+            restock_tool = vending_tools_module.restock_machine()
+
+            with pytest.raises(ToolException) as exc_info:
+                restock_tool(sku="chips", quantity=10, column=1)
+
+            assert "row is required to complete this action" in str(exc_info.value)
+
+    def test_restock_missing_column_triggers_exception(self, vending_tools_module, mock_env):
+        """Test that missing column in restock triggers ToolException."""
+        with patch("examples.vending_bench.tools.get_env", return_value=mock_env):
+            restock_tool = vending_tools_module.restock_machine()
+
+            with pytest.raises(ToolException) as exc_info:
+                restock_tool(sku="chips", quantity=10, row=1)
+
+            assert "column is required to complete this action" in str(exc_info.value)
 
     def test_restock_successful_flow(self, vending_tools_module, mock_env):
         """Test that valid restock parameters succeed."""
@@ -164,66 +205,75 @@ class TestRestockMachineClarificationLoop:
             restock_tool = vending_tools_module.restock_machine()
 
             # Should not raise exception
-            result = restock_tool(sku="chips", quantity=20)
+            result = restock_tool(sku="chips", quantity=20, row=1, column=1)
 
             # Verify the environment methods were called
-            mock_env.restock.assert_called_once_with("chips", 20)
-            mock_env.advance_time.assert_called_once_with(15)
+            mock_env.restock.assert_called_once_with("chips", 20, row=0, column=0)  # Tools convert to 0-indexed
+            mock_env.advance_time.assert_called_once_with(75)  # Updated to match tools.py
 
             # Verify result structure
             assert result.sku == "chips"
             assert result.quantity_restocked == 20
+            assert result.row == 1  # Original 1-indexed input
+            assert result.column == 1  # Original 1-indexed input
 
 
 class TestSetPriceClarificationLoop:
     """Test clarification loop for set_price tool."""
 
-    def test_set_price_missing_sku_triggers_exception(self, vending_tools_module, mock_env):
-        """Test that missing SKU in set_price triggers ToolException."""
+    def test_set_price_empty_updates_triggers_exception(self, vending_tools_module, mock_env):
+        """Test that empty updates list triggers ValueError."""
         with patch("examples.vending_bench.tools.get_env", return_value=mock_env):
             price_tool = vending_tools_module.set_price()
 
-            with pytest.raises(ToolException) as exc_info:
-                price_tool(sku=None, price=2.50)
+            with pytest.raises(ValueError) as exc_info:
+                price_tool(updates=[])
 
-            assert "sku is required to complete this action" in str(exc_info.value)
+            assert "updates must not be empty" in str(exc_info.value)
 
-    def test_set_price_missing_price_triggers_exception(self, vending_tools_module, mock_env):
-        """Test that missing price in set_price triggers ToolException."""
+    def test_set_price_empty_slot_triggers_exception(self, vending_tools_module, mock_env):
+        """Test that updating an empty slot triggers ToolException."""
         with patch("examples.vending_bench.tools.get_env", return_value=mock_env):
             price_tool = vending_tools_module.set_price()
+            updates = [SlotPriceUpdate(row=2, column=2, price=2.50)]  # Empty slot (2,2 -> 1,1 in 0-indexed)
 
             with pytest.raises(ToolException) as exc_info:
-                price_tool(sku="chips", price=None)
+                price_tool(updates=updates)
 
-            assert "price is required to complete this action" in str(exc_info.value)
+            assert "slot (2, 2) is empty" in str(exc_info.value)
 
     def test_set_price_negative_price_triggers_exception(self, vending_tools_module, mock_env):
-        """Test that negative price triggers ToolException."""
+        """Test that negative price triggers ValueError."""
         with patch("examples.vending_bench.tools.get_env", return_value=mock_env):
             price_tool = vending_tools_module.set_price()
+            updates = [SlotPriceUpdate(row=1, column=1, price=-1.50)]
 
-            with pytest.raises(ToolException) as exc_info:
-                price_tool(sku="chips", price=-1.50)
+            with pytest.raises(ValueError) as exc_info:
+                price_tool(updates=updates)
 
-            assert "price must be greater than zero" in str(exc_info.value)
+            assert "price must be positive" in str(exc_info.value)
 
     def test_set_price_successful_flow(self, vending_tools_module, mock_env):
         """Test that valid set_price parameters succeed."""
         with patch("examples.vending_bench.tools.get_env", return_value=mock_env):
             price_tool = vending_tools_module.set_price()
+            updates = [SlotPriceUpdate(row=1, column=1, price=1.75)]  # 1-indexed input
 
             # Should not raise exception
-            result = price_tool(sku="chips", price=1.75)
+            result = price_tool(updates=updates)
 
             # Verify the environment methods were called
-            mock_env.set_price.assert_called_once_with("chips", 1.75)
-            mock_env.advance_time.assert_called_once_with(5)
+            mock_env.set_price.assert_called_once_with({(0, 0): 1.75})  # Converted to 0-indexed
+            mock_env.advance_time.assert_called_once_with(300)  # 5 hours as per tools.py
 
             # Verify result structure
-            assert result.sku == "chips"
-            assert result.new_price == 1.75
-            assert result.old_price == 1.50  # From mock_env
+            assert len(result.updates) == 1
+            update_result = result.updates[0]
+            assert update_result.row == 1  # Original 1-indexed input
+            assert update_result.column == 1  # Original 1-indexed input
+            assert update_result.sku == "chips"
+            assert update_result.new_price == 1.75
+            assert update_result.old_price == 1.50  # From mock_env
 
 
 class TestPlaceOrderClarificationLoop:


### PR DESCRIPTION
## What & Why

  Align vending tools with 0-indexed simulator slots to eliminate
  off-by-one restock and price updates, and extend clarification tests to
  cover the revised contract.【F:examples/vending_bench/tools.py-L650-L758】【F:tests/integration_vending_bench/test_clarification_loop.py-L24-L276】

  Scope
  Out of scope: broader supervisor tool validation and other vending
  bench helpers.【F:examples/vending_bench/tools.py-L650-L758】

  ## Changes

  - Translate 1-indexed restock and price coordinates before touching the
    environment while keeping user-facing telemetry untouched.【F:examples_vending_bench/tools.py-L650-L758】
  - Rebuild the vending bench mock environment with slot grids and expand
    clarification tests for missing row or column inputs and new
    SlotPriceUpdate flows.【F:tests/integration_vending_bench/test_clarification_loop.py-L24-L276】

  Affected areas

  - examples/vending_bench/tools.py
  - tests/integration/vending_bench/test_clarification_loop.py

  ## Risk & Rollback

  Risk checklist

  - [ ] Breaking change (compat plan described)
  - [ ] Data migration/backfill (plan + window)
  - [ ] Security/privacy change (perms/secrets/PII)
  - [ ] Performance impact (baseline vs. new)
  - [ ] Observability updated (metrics/logs/alerts)
  - [ ] Feature flag (name, rollout, kill-switch tested)

  Rollback
  Revert commits fix(vending_bench): align env slot indexing and
  test(vending_bench): expand clarification coverage together to restore
  prior behavior.

  ## Test Plan

  Automated

  - Unit: Blocked by missing external/inspect_ai/pyproject.toml in the
    vendored dependency; full uv run pytest fails up front.【F:.tmp_pytest_full.log-L1】
  - Integration/E2E: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python -m pytest -q tests/integration/vending_bench/test_clarification_loop.py
    (passed).【F:.tmp_pytest_vending.log-L1】

  Manual / Evidence

  - Steps + expected signals: Not applicable
  - UI (if applicable): Not applicable
  - Performance (if applicable): Not applicable

  ## Follow-ups (optional)

  - Restore the vendored Inspect-AI configuration so repository-wide
    uv run pytest pipelines succeed again.【F:.tmp_pytest_full.log-L1】

  ## All sources

  S1 → examples/vending_bench/tools.py-L650-L758
  S2 → tests/integration/vending_bench/test_clarification_loop.py-L24-L276
  S3 → .tmp_pytest_full.log-L1
  S4 → .tmp_pytest_vending.log-L1
