### PR TITLE
feat: add supplier email procurement flow

### DIFF
--- a/examples/vending_bench/env.py
+++ b/examples/vending_bench/env.py
@@ -19,13 +19,14 @@ from .state import (
     DemandProfile,
     EmailMessage,
     Order,
+    QueuedEmail,
     SimulatorState,
     Slot,
     aggregate_sku_quantities,
     clone_machine_inventory,
     serialize_machine_inventory,
 )
-from .supplier import SupplierModel
+from .supplier import SupplierEmailResponse, SupplierModel
 
 
 @dataclass
@@ -56,7 +57,7 @@ class VendingEnv:
             self.state.demand_profiles.keys(),
             profiles=self.state.demand_profiles,
         )
-        self._supplier = SupplierModel(self.config.seed + 2)
+        self._supplier = SupplierModel(self.config.seed + 2, self.state.demand_profiles)
         self._morning_initialised = False
 
     @staticmethod
@@ -131,6 +132,16 @@ class VendingEnv:
 
     def _process_morning_flow(self) -> None:
         self._normalize_machine_inventory()
+
+        # Deliver any supplier emails scheduled for this morning before deliveries land
+        if self.state.scheduled_inbox:
+            pending: list[QueuedEmail] = []
+            for scheduled in self.state.scheduled_inbox:
+                if scheduled.delivery_day <= self.state.day:
+                    self.state.inbox.append(scheduled.message)
+                else:
+                    pending.append(scheduled)
+            self.state.scheduled_inbox = pending
 
         # Deliver orders
         delivered, pending = self._supplier.split_deliveries(self.state.outstanding_orders, self.state.day)
@@ -257,27 +268,24 @@ class VendingEnv:
             recipient=recipient,
         )
         self.state.outbox.append(message)
+
+        response: SupplierEmailResponse = self._supplier.process_email(self.state, message)
+        if response.reply is not None:
+            scheduled = QueuedEmail(delivery_day=message.day + 1, message=response.reply)
+            self.state.scheduled_inbox.append(scheduled)
+        if response.orders:
+            total_cost = sum(order.total_cost for order in response.orders)
+            if self.state.cash_balance < total_cost:
+                # Should not happen because the supplier checks balance, but guard just in case.
+                raise ValueError("insufficient cash to process supplier order")
+            self.state.cash_balance -= total_cost
+            self._update_negative_balance_days()
+            self.state.outstanding_orders.extend(response.orders)
+
         return message
 
     def place_order(self, sku: str, quantity: int) -> Order:
-        profile = self.state.demand_profiles.get(sku)
-        if profile is None:
-            raise ValueError(f"Unknown SKU {sku}")
-        self._demand.ensure_profiles({sku: profile})
-        product = profile.product
-        order = self._supplier.create_order(product=product, quantity=quantity, day_ordered=self.state.day)
-        total_cost = order.total_cost
-        if self.state.cash_balance < total_cost:
-            raise ValueError("insufficient cash to place order")
-        self.state.cash_balance -= total_cost
-        self.state.outstanding_orders.append(order)
-        self.queue_email(
-            recipient="supplier@sim",
-            subject=f"Purchase order {order.sku}",
-            body=f"Ordered {order.quantity} units for ${total_cost:.2f}, delivery day {order.delivery_day}",
-            sender="agent@sim",
-        )
-        return order
+        raise RuntimeError("Direct ordering is disabled; send a purchase order email to a supplier instead.")
 
     def summary(self) -> EnvSummary:
         machine_slots = clone_machine_inventory(self.state.machine_inventory)

--- a/examples/vending_bench/state.py
+++ b/examples/vending_bench/state.py
@@ -61,6 +61,27 @@ class DemandProfile:
 
 
 @dataclass
+class SupplierProductOffer:
+    """Static supplier offer data for a SKU."""
+
+    product: Product
+    wholesale_price: float
+    min_order_quantity: int
+    lead_time_days: tuple[int, int]
+    keywords: tuple[str, ...]
+
+
+@dataclass
+class SupplierContact:
+    """Supplier directory entry used for deterministic email responses."""
+
+    name: str
+    email: str
+    categories: tuple[str, ...]
+    products: dict[str, SupplierProductOffer]
+
+
+@dataclass
 class Order:
     sku: str
     quantity: int
@@ -80,6 +101,14 @@ class EmailMessage:
     body: str
     sender: str
     recipient: str
+
+
+@dataclass
+class QueuedEmail:
+    """Scheduled email set to arrive on a future morning."""
+
+    delivery_day: int
+    message: EmailMessage
 
 
 @dataclass
@@ -110,6 +139,7 @@ class SimulatorState:
     outstanding_orders: list[Order] = field(default_factory=list)
     inbox: list[EmailMessage] = field(default_factory=list)
     outbox: list[EmailMessage] = field(default_factory=list)
+    scheduled_inbox: list[QueuedEmail] = field(default_factory=list)
     units_sold_today: dict[str, int] = field(default_factory=dict)
     daily_reports: list[DailyReport] = field(default_factory=list)
     negative_balance_days: int = 0

--- a/examples/vending_bench/supplier.py
+++ b/examples/vending_bench/supplier.py
@@ -1,12 +1,24 @@
-"""Deterministic supplier fixtures for the vending simulator."""
+"""Deterministic supplier fixtures and email responders for the vending simulator."""
 
 from __future__ import annotations
 
 import random
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from .state import Order, Product
+from .state import (
+    EmailMessage,
+    Order,
+    Product,
+    SimulatorState,
+    SupplierContact,
+    SupplierProductOffer,
+)
+
+if TYPE_CHECKING:
+    from .state import DemandProfile
 
 
 @dataclass(frozen=True)
@@ -21,43 +33,136 @@ class SupplierConfig:
             raise ValueError("max_lead_time_days must be >= min_lead_time_days")
 
 
-class SupplierModel:
-    """Pseudo-random but seedable supplier that returns deterministic lead times."""
+@dataclass
+class SupplierEmailResponse:
+    """Result of processing an outbound email to a supplier."""
 
-    def __init__(self, seed: int, config: SupplierConfig | None = None) -> None:
+    reply: EmailMessage | None
+    orders: list[Order]
+
+
+class SupplierModel:
+    """Seeded supplier model that responds to emails and schedules orders."""
+
+    QUOTE_KEYWORDS = ("quote", "pricing", "price list", "catalog", "product list", "availability")
+    PURCHASE_KEYWORDS = ("order", "purchase", "buy")
+
+    def __init__(
+        self,
+        seed: int,
+        catalogue: dict[str, DemandProfile],
+        config: SupplierConfig | None = None,
+    ) -> None:
         self._rng = random.Random(seed)
         self.config = config or SupplierConfig()
         self.config.validate()
 
-    def quote_unit_cost(self, product: Product) -> float:
-        """Return the deterministic unit cost (can be extended for markups)."""
+        # Copy base product data for deterministic offers
+        self._products: dict[str, Product] = {sku: profile.product for sku, profile in catalogue.items()}
+        self._contacts = self._build_contacts()
 
-        return product.unit_cost
+    def supplier_directory(self) -> dict[str, SupplierContact]:
+        """Expose the supplier directory for inspection/testing."""
 
-    def draw_lead_time(self, product: Product) -> int:
-        """Sample a deterministic lead time based on the RNG sequence."""
+        return self._contacts.copy()
 
-        span = self.config.max_lead_time_days - self.config.min_lead_time_days
-        if span == 0:
-            return self.config.min_lead_time_days
-        return self.config.min_lead_time_days + self._rng.randint(0, span)
+    def process_email(self, state: SimulatorState, message: EmailMessage) -> SupplierEmailResponse:
+        """Return a reply and optional order(s) in response to an outbound email."""
 
-    def create_order(self, *, product: Product, quantity: int, day_ordered: int) -> Order:
-        if quantity <= 0:
-            raise ValueError("quantity must be positive")
-        lead_time = self.draw_lead_time(product)
-        delivery_day = day_ordered + max(1, lead_time)
-        unit_cost = self.quote_unit_cost(product)
-        return Order(
-            sku=product.sku,
-            quantity=quantity,
-            unit_cost=unit_cost,
-            day_ordered=day_ordered,
-            delivery_day=delivery_day,
+        contact = self._contacts.get(message.recipient.lower())
+        if contact is None:
+            return SupplierEmailResponse(reply=None, orders=[])
+
+        lower_subject = message.subject.lower()
+        lower_body = message.body.lower()
+
+        if self._is_quote_request(lower_subject, lower_body):
+            reply = self._quote_response(contact, message, state.day)
+            return SupplierEmailResponse(reply=reply, orders=[])
+
+        if self._is_purchase_request(lower_subject, lower_body):
+            requested = self._parse_purchase_quantities(contact, lower_body)
+            if not requested:
+                return SupplierEmailResponse(
+                    reply=self._clarification_response(
+                        contact, message, "Please specify quantities for each SKU you'd like to order.", state.day
+                    ),
+                    orders=[],
+                )
+
+            missing_requirements: list[str] = []
+            for sku, qty in requested.items():
+                offer = contact.products[sku]
+                if qty < offer.min_order_quantity:
+                    missing_requirements.append(
+                        f"{offer.product.name} (SKU {sku}) requires a minimum order of {offer.min_order_quantity} units"
+                    )
+
+            if missing_requirements:
+                return SupplierEmailResponse(
+                    reply=self._clarification_response(
+                        contact,
+                        message,
+                        "\n".join(missing_requirements),
+                        state.day,
+                    ),
+                    orders=[],
+                )
+
+            if not self._has_account_info(lower_body):
+                return SupplierEmailResponse(
+                    reply=self._clarification_response(
+                        contact,
+                        message,
+                        "Please include your account number so we can process the purchase order.",
+                        state.day,
+                    ),
+                    orders=[],
+                )
+
+            if not self._has_delivery_address(lower_body):
+                return SupplierEmailResponse(
+                    reply=self._clarification_response(
+                        contact,
+                        message,
+                        "Please confirm the delivery address to schedule shipment.",
+                        state.day,
+                    ),
+                    orders=[],
+                )
+
+            offers = [contact.products[sku] for sku in requested.keys()]
+            total_cost = sum(requested[offer.product.sku] * offer.wholesale_price for offer in offers)
+            if state.cash_balance < total_cost:
+                return SupplierEmailResponse(
+                    reply=self._clarification_response(
+                        contact,
+                        message,
+                        (
+                            "We cannot process the order because your available cash ($"
+                            f"{state.cash_balance:.2f}) is below the order total of ${total_cost:.2f}."
+                        ),
+                        state.day,
+                    ),
+                    orders=[],
+                )
+
+            orders = [self._create_order(offer, requested[offer.product.sku], state.day) for offer in offers]
+            reply = self._order_confirmation(contact, message, orders, state.day)
+            return SupplierEmailResponse(reply=reply, orders=orders)
+
+        # Default response asking for clarification when the intent is unclear
+        return SupplierEmailResponse(
+            reply=self._clarification_response(
+                contact,
+                message,
+                "Let us know if you need a price quote or want to place an order.",
+                state.day,
+            ),
+            orders=[],
         )
 
-    @staticmethod
-    def split_deliveries(orders: Iterable[Order], current_day: int) -> tuple[list[Order], list[Order]]:
+    def split_deliveries(self, orders: Iterable[Order], current_day: int) -> tuple[list[Order], list[Order]]:
         """Partition orders into delivered vs pending based on the current day."""
 
         delivered: list[Order] = []
@@ -68,3 +173,190 @@ class SupplierModel:
             else:
                 pending.append(order)
         return delivered, pending
+
+    # Internal helpers -----------------------------------------------------------------
+
+    def _build_contacts(self) -> dict[str, SupplierContact]:
+        """Construct deterministic supplier directory."""
+
+        def make_offer(
+            sku: str,
+            *,
+            wholesale_price: float | None = None,
+            min_order: int,
+            lead: tuple[int, int],
+            extra_keywords: tuple[str, ...] = (),
+        ) -> SupplierProductOffer:
+            product = self._products[sku]
+            price = wholesale_price if wholesale_price is not None else product.unit_cost
+            keywords = {sku.lower(), product.name.lower()}
+            keywords.add(product.name.lower().replace(" ", ""))
+            keywords.update(extra_keywords)
+            return SupplierProductOffer(
+                product=product,
+                wholesale_price=price,
+                min_order_quantity=min_order,
+                lead_time_days=lead,
+                keywords=tuple(sorted(keywords)),
+            )
+
+        contacts = [
+            SupplierContact(
+                name="Regional Food Distributors Inc.",
+                email="orders@rfd-inc.com",
+                categories=("beverage", "snack"),
+                products={
+                    sku: make_offer(
+                        sku,
+                        wholesale_price=self._products[sku].unit_cost * 0.95,
+                        min_order=24 if sku != "energy_drink" else 12,
+                        lead=(2, 5),
+                    )
+                    for sku in ("coke", "water", "energy_drink")
+                    if sku in self._products
+                },
+            ),
+            SupplierContact(
+                name="QuickStock Vending Solutions",
+                email="supply@quickstock.com",
+                categories=("snack", "impulse"),
+                products={
+                    sku: make_offer(
+                        sku,
+                        wholesale_price=self._products[sku].unit_cost * 0.9,
+                        min_order=12,
+                        lead=(1, 3),
+                    )
+                    for sku in ("chips", "chocolate_bar", "energy_drink")
+                    if sku in self._products
+                },
+            ),
+            SupplierContact(
+                name="Metro Wholesale Foods",
+                email="sales@metrofoods.example",
+                categories=("balanced", "office"),
+                products={
+                    sku: make_offer(
+                        sku,
+                        wholesale_price=self._products[sku].unit_cost,
+                        min_order=18,
+                        lead=(3, 6),
+                        extra_keywords=(self._products[sku].variety_class.lower(),),
+                    )
+                    for sku in self._products.keys()
+                },
+            ),
+        ]
+
+        return {contact.email.lower(): contact for contact in contacts if contact.products}
+
+    def _is_quote_request(self, subject: str, body: str) -> bool:
+        return any(keyword in subject or keyword in body for keyword in self.QUOTE_KEYWORDS)
+
+    def _is_purchase_request(self, subject: str, body: str) -> bool:
+        return any(keyword in subject or keyword in body for keyword in self.PURCHASE_KEYWORDS)
+
+    def _parse_purchase_quantities(self, contact: SupplierContact, lower_body: str) -> dict[str, int]:
+        requested: dict[str, int] = {}
+        for sku, offer in contact.products.items():
+            patterns = {re.escape(keyword) for keyword in offer.keywords}
+            for pattern in patterns:
+                regex = re.compile(rf"(\d+)\s+(?:units?\s+of\s+)?{pattern}\b")
+                for match in regex.finditer(lower_body):
+                    quantity = int(match.group(1))
+                    requested[sku] = requested.get(sku, 0) + quantity
+        return requested
+
+    def _has_account_info(self, lower_body: str) -> bool:
+        if "account" not in lower_body:
+            return False
+        return bool(re.search(r"account\s*(?:number|#|no\.?|acct)?\s*[:#]?\s*[a-z0-9-]{4,}", lower_body))
+
+    def _has_delivery_address(self, lower_body: str) -> bool:
+        if "address" in lower_body:
+            return True
+        return "deliver" in lower_body and "to" in lower_body
+
+    def _quote_response(self, contact: SupplierContact, message: EmailMessage, current_day: int) -> EmailMessage:
+        lines = [
+            f"Hello, this is {contact.name}.",
+            "Here are our current wholesale options:",
+        ]
+        for offer in sorted(contact.products.values(), key=lambda o: o.product.name):
+            lead_min, lead_max = offer.lead_time_days
+            lead_text = f"{lead_min} day" if lead_min == lead_max else f"{lead_min}-{lead_max} day"
+            lines.append(
+                f"- {offer.product.name} (SKU {offer.product.sku}): "
+                f"${offer.wholesale_price:.2f} per unit, MOQ {offer.min_order_quantity}, "
+                f"lead time {lead_text}s"
+            )
+        lines.append("Let us know if you'd like to place an order.")
+        body = "\n".join(lines)
+        return EmailMessage(
+            day=current_day + 1,
+            subject=f"Re: {message.subject or 'Supplier inquiry'}",
+            body=body,
+            sender=contact.email,
+            recipient=message.sender,
+        )
+
+    def _clarification_response(
+        self,
+        contact: SupplierContact,
+        message: EmailMessage,
+        reason: str,
+        current_day: int,
+    ) -> EmailMessage:
+        body = (
+            f"Hello, this is {contact.name}.\n"
+            f"{reason}\n"
+            "Feel free to reply with the missing details or request an updated quote."
+        )
+        return EmailMessage(
+            day=current_day + 1,
+            subject=f"Re: {message.subject or 'Supplier request'}",
+            body=body,
+            sender=contact.email,
+            recipient=message.sender,
+        )
+
+    def _order_confirmation(
+        self,
+        contact: SupplierContact,
+        message: EmailMessage,
+        orders: list[Order],
+        current_day: int,
+    ) -> EmailMessage:
+        lines = [
+            "Thanks for your purchase order. We've scheduled the following items:",
+        ]
+        for order in orders:
+            lines.append(
+                f"- {order.quantity} units of {self._products[order.sku].name} "
+                f"(SKU {order.sku}) arriving day {order.delivery_day} at ${order.total_cost:.2f}."
+            )
+        total_cost = sum(order.total_cost for order in orders)
+        lines.append(f"Total cost debited: ${total_cost:.2f}.")
+        lines.append("Reach out if you need to adjust quantities or delivery timing.")
+        body = "\n".join(lines)
+        return EmailMessage(
+            day=current_day + 1,
+            subject=f"Order confirmation #{message.day}-{current_day + 1}",
+            body=body,
+            sender=contact.email,
+            recipient=message.sender,
+        )
+
+    def _create_order(self, offer: SupplierProductOffer, quantity: int, day_ordered: int) -> Order:
+        lead_min, lead_max = offer.lead_time_days
+        if lead_min == lead_max:
+            delivery_day = day_ordered + max(1, lead_min)
+        else:
+            delivery_day = day_ordered + max(1, self._rng.randint(lead_min, lead_max))
+        return Order(
+            sku=offer.product.sku,
+            quantity=quantity,
+            unit_cost=offer.wholesale_price,
+            day_ordered=day_ordered,
+            delivery_day=delivery_day,
+        )

--- a/examples/vending_bench/tools.py
+++ b/examples/vending_bench/tools.py
@@ -127,16 +127,6 @@ class MachineInventoryResult(BaseModel):
     slots: list[MachineInventorySlot]
 
 
-class PlaceOrderResult(BaseModel):
-    """Result from order placement."""
-
-    order_id: str
-    sku: str
-    quantity: int
-    total_cost: float
-    delivery_day: int
-
-
 class CollectCashResult(BaseModel):
     """Result from cash collection."""
 
@@ -796,73 +786,6 @@ def set_price() -> Tool:
     return set_price_impl
 
 
-def place_order() -> Tool:
-    """Place an order with suppliers for inventory."""
-
-    from inspect_ai.tool._tool import tool
-
-    @tool(name="place_order")
-    def place_order_impl(sku: str | None = None, quantity: int | None = None) -> PlaceOrderResult:
-        """Place supplier order for inventory with automatic cost deduction.
-
-        Args:
-            sku: Product SKU to order
-            quantity: Number of units to order
-        """
-
-        validated_sku = _require_non_empty_string("sku", sku)
-        validated_quantity = _require_positive_int("quantity", quantity)
-
-        t0 = _log_tool_event(
-            name="place_order",
-            phase="start",
-            args={"sku": validated_sku, "quantity": validated_quantity},
-        )
-
-        try:
-            env = get_env()
-
-            _require_known_sku(env, validated_sku)
-
-            order = env.place_order(validated_sku, validated_quantity)
-            env.advance_time(25)  # 25 minutes to compose and send the supplier email
-
-            result = PlaceOrderResult(
-                order_id=f"{order.sku}_{order.day_ordered}_{len(env.state.outstanding_orders)}",
-                sku=order.sku,
-                quantity=order.quantity,
-                total_cost=order.total_cost,
-                delivery_day=order.delivery_day,
-            )
-
-            _log_tool_event(
-                name="place_order",
-                phase="end",
-                extra={
-                    "sku": order.sku,
-                    "quantity": order.quantity,
-                    "total_cost": order.total_cost,
-                    "delivery_day": order.delivery_day,
-                },
-                t0=t0,
-            )
-
-            return result
-
-        except Exception as e:
-            _log_tool_event(
-                name="place_order",
-                phase="error",
-                extra={"error": str(e), "sku": validated_sku},
-                t0=t0,
-            )
-            if isinstance(e, ToolException):
-                raise
-            raise ToolException(f"Order placement failed: {str(e)}")
-
-    return place_order_impl
-
-
 def collect_cash() -> Tool:
     """Collect cash from the vending machine."""
 
@@ -975,30 +898,89 @@ def ai_web_search() -> Tool:
             env = get_env()
             env.advance_time(60)  # 1 hour for research
 
-            # Deterministic stub results based on query content
-            stub_results = []
-            if "supplier" in query.lower() or "vendor" in query.lower():
-                stub_results = [
+            # Enhanced deterministic supplier search results with dynamic content based on catalog
+            stub_results: list[dict[str, Any]] = []
+            normalized_query = query.lower()
+
+            # Get available SKUs from environment catalog
+            available_skus = set(env.state.demand_profiles.keys())
+
+            if any(term in normalized_query for term in ("supplier", "vendor", "wholesale", "contact")):
+                # Build dynamic supplier results based on available catalog
+                suppliers_data = [
                     {
-                        "title": "Regional Food Distributors Inc.",
+                        "name": "Regional Food Distributors Inc.",
+                        "email": "orders@rfd-inc.com",
+                        "phone": "+1-800-555-0110",
                         "url": "https://example-supplier1.com",
-                        "snippet": "Bulk snack and beverage supplier with 2-5 day lead times. Competitive pricing on popular vending items.",
-                        "contact": "orders@rfd-inc.com",
+                        "snippet": "Bulk beverage catalogue with predictable 2-5 day delivery windows across the Midwest.",
+                        "categories": ["beverage"],
+                        "specialties": ["coke", "water", "energy_drink"],
+                        "min_orders": {"coke": 24, "water": 24, "energy_drink": 12},
+                        "price_multiplier": 0.95,
+                        "lead_time": "2-5"
                     },
                     {
-                        "title": "QuickStock Vending Solutions",
+                        "name": "QuickStock Vending Solutions",
+                        "email": "supply@quickstock.com",
+                        "phone": "+1-800-555-0148",
                         "url": "https://example-supplier2.com",
-                        "snippet": "Specialized vending machine inventory supplier. Same-day delivery available for local area.",
-                        "contact": "supply@quickstock.com",
+                        "snippet": "Fast-turn snack distributor with local cross-dock for 1-3 day replenishment.",
+                        "categories": ["snack", "impulse"],
+                        "specialties": ["chips", "chocolate_bar", "energy_drink"],
+                        "min_orders": {"chips": 12, "chocolate_bar": 12, "energy_drink": 12},
+                        "price_multiplier": 0.90,
+                        "lead_time": "1-3"
                     },
+                    {
+                        "name": "Metro Wholesale Foods",
+                        "email": "sales@metrofoods.example",
+                        "phone": "+1-800-555-0190",
+                        "url": "https://example-supplier3.com",
+                        "snippet": "Balanced assortment for office routes with 3-6 day scheduled deliveries.",
+                        "categories": ["balanced", "office"],
+                        "specialties": list(available_skus),
+                        "min_orders": {sku: 18 for sku in available_skus},
+                        "price_multiplier": 1.0,
+                        "lead_time": "3-6"
+                    }
                 ]
-            elif "product" in query.lower() or "snack" in query.lower():
+
+                for supplier in suppliers_data:
+                    # Build catalog for available SKUs
+                    catalog = []
+                    for sku in supplier["specialties"]:
+                        if sku in available_skus:
+                            profile = env.state.demand_profiles[sku]
+                            wholesale_price = profile.product.unit_cost * supplier["price_multiplier"]
+                            catalog.append({
+                                "sku": sku,
+                                "name": profile.product.name,
+                                "category": "beverage" if "beverage" in supplier["categories"] else profile.product.variety_class.lower(),
+                                "min_order": supplier["min_orders"].get(sku, 18),
+                                "wholesale_price": round(wholesale_price, 2),
+                                "lead_time_days": supplier["lead_time"]
+                            })
+
+                    if catalog:  # Only include suppliers with available products
+                        stub_results.append({
+                            "title": supplier["name"],
+                            "url": supplier["url"],
+                            "snippet": supplier["snippet"],
+                            "contact": {"email": supplier["email"], "phone": supplier["phone"]},
+                            "categories": supplier["categories"],
+                            "catalog": catalog
+                        })
+            elif any(term in normalized_query for term in ("product list", "snack", "catalogue", "pricing")):
                 stub_results = [
                     {
-                        "title": "Popular Vending Machine Snacks 2024",
+                        "title": "Top vending machine performers",
                         "url": "https://example-market-research.com",
-                        "snippet": "Analysis of top-selling vending items. Chips, candy, and energy drinks lead sales.",
-                        "data": "market_trends",
+                        "snippet": "Chilled beverages and grab-and-go snacks drive 68% of office vending revenue.",
+                        "data": {
+                            "beverage": {"top_skus": ["coke", "water", "energy_drink"], "avg_wholesale": 0.60},
+                            "snack": {"top_skus": ["chips", "chocolate_bar"], "avg_wholesale": 0.62},
+                        },
                     }
                 ]
 
@@ -1020,13 +1002,11 @@ def ai_web_search() -> Tool:
 def supervisor_tools() -> list[Tool]:
     """Return list of tools available to the supervisor agent."""
     return [
-        check_inventory(),
         check_storage_inventory(),
         check_machine_overview(),
         read_email(),
         send_email(),
         check_financial_status(),
-        place_order(),
         wait_for_next_day(),
         ai_web_search(),
     ]
@@ -1054,7 +1034,6 @@ def all_vending_tools() -> list[Tool]:
         check_financial_status(),
         restock_machine(),
         set_price(),
-        place_order(),
         collect_cash(),
         wait_for_next_day(),
         ai_web_search(),

--- a/tests/integration/vending_bench/test_clarification_loop.py
+++ b/tests/integration/vending_bench/test_clarification_loop.py
@@ -276,28 +276,6 @@ class TestSetPriceClarificationLoop:
             assert update_result.old_price == 1.50  # From mock_env
 
 
-class TestPlaceOrderClarificationLoop:
-    """Test clarification loop for place_order tool."""
-
-    def test_place_order_missing_sku_triggers_exception(self, vending_tools_module, mock_env):
-        """Test that missing SKU in place_order triggers ToolException."""
-        with patch("examples.vending_bench.tools.get_env", return_value=mock_env):
-            order_tool = vending_tools_module.place_order()
-
-            with pytest.raises(ToolException) as exc_info:
-                order_tool(sku=None, quantity=50)
-
-            assert "sku is required to complete this action" in str(exc_info.value)
-
-    def test_place_order_missing_quantity_triggers_exception(self, vending_tools_module, mock_env):
-        """Test that missing quantity in place_order triggers ToolException."""
-        with patch("examples.vending_bench.tools.get_env", return_value=mock_env):
-            order_tool = vending_tools_module.place_order()
-
-            with pytest.raises(ToolException) as exc_info:
-                order_tool(sku="chips", quantity=None)
-
-            assert "quantity is required to complete this action" in str(exc_info.value)
 
 
 class TestClarificationLoopIntegration:

--- a/tests/unit/vending_bench/test_env.py
+++ b/tests/unit/vending_bench/test_env.py
@@ -5,6 +5,20 @@ import pytest
 from examples.vending_bench import EnvConfig, VendingEnv
 from examples.vending_bench.state import aggregate_sku_quantities
 
+SUPPLIER_EMAIL = "orders@rfd-inc.com"
+
+
+def _purchase_order_body() -> str:
+    return (
+        "Hello supplier,\n"
+        "Please process the following purchase order:\n"
+        "- 24 coke\n"
+        "- 12 energy_drink\n"
+        "Delivery address: 100 Market St, Unit 5, Springfield\n"
+        "Account number: ACCT-123456\n"
+        "Thank you!"
+    )
+
 
 def test_env_initialization():
     """Test basic environment initialization."""
@@ -20,19 +34,22 @@ def test_env_initialization():
 
 
 def test_deterministic_behavior_with_same_seed():
-    """Test that same seed produces identical results."""
+    """Test that same seed produces identical supplier responses."""
     config1 = EnvConfig(seed=42)
     config2 = EnvConfig(seed=42)
 
     env1 = VendingEnv(config1)
     env2 = VendingEnv(config2)
 
-    # Place same orders
-    order1 = env1.place_order("coke", 5)
-    order2 = env2.place_order("coke", 5)
+    body = _purchase_order_body()
+    env1.queue_email(recipient=SUPPLIER_EMAIL, subject="Purchase order", body=body)
+    env2.queue_email(recipient=SUPPLIER_EMAIL, subject="Purchase order", body=body)
 
-    assert order1.delivery_day == order2.delivery_day
-    assert order1.unit_cost == order2.unit_cost
+    assert len(env1.state.outstanding_orders) == len(env2.state.outstanding_orders) == 2
+    for order1, order2 in zip(env1.state.outstanding_orders, env2.state.outstanding_orders, strict=True):
+        assert order1.delivery_day == order2.delivery_day
+        assert order1.unit_cost == pytest.approx(order2.unit_cost)
+        assert order1.quantity == order2.quantity
 
 
 def test_advance_time():
@@ -121,19 +138,53 @@ def test_demand_model_slot_sales_distribution():
         assert (0, 1) in outcome.slot_sales
 
 
-def test_place_order():
-    """Test placing orders."""
+def test_email_purchase_creates_orders_and_deducts_cash():
+    """Purchasing via email should create orders, deduct cash, and queue supplier confirmation."""
+    env = VendingEnv()
+    starting_cash = env.state.cash_balance
+
+    body = _purchase_order_body()
+    env.queue_email(recipient=SUPPLIER_EMAIL, subject="Purchase order", body=body)
+
+    assert len(env.state.outstanding_orders) == 2
+    total_order_cost = sum(order.total_cost for order in env.state.outstanding_orders)
+    assert env.state.cash_balance == pytest.approx(starting_cash - total_order_cost)
+    # Replies should be scheduled for the next day, not immediately delivered
+    assert env.state.inbox == []
+    assert env.state.scheduled_inbox
+
+    env.end_of_day()
+
+    # Reply arrives the following morning alongside the daily summary email
+    supplier_messages = [msg for msg in env.state.inbox if msg.sender == SUPPLIER_EMAIL]
+    assert supplier_messages, "Expected supplier confirmation in the inbox"
+
+
+def test_supplier_quote_request_reply_next_day():
+    """Supplier quote requests should produce next-day replies with catalog details."""
     env = VendingEnv()
 
-    order = env.place_order("coke", 10)
+    env.queue_email(
+        recipient="supply@quickstock.com",
+        subject="Need wholesale pricing",
+        body="Please send your product list and pricing tiers.",
+    )
 
-    assert order.sku == "coke"
-    assert order.quantity == 10
-    assert order.day_ordered == 0
-    assert order.delivery_day > 0
-    assert env.state.cash_balance < 500.0  # Cost deducted
-    assert len(env.state.outstanding_orders) == 1
-    assert len(env.state.outbox) == 1  # Email sent
+    assert env.state.scheduled_inbox
+    env.end_of_day()
+    quote_messages = [msg for msg in env.state.inbox if msg.sender == "supply@quickstock.com"]
+    assert len(quote_messages) == 1
+    body_lower = quote_messages[0].body.lower()
+    assert "moq" in body_lower or "min order" in body_lower
+
+
+def test_unknown_email_gets_no_reply():
+    """Emails to unknown recipients should not generate replies."""
+    env = VendingEnv()
+
+    env.queue_email(recipient="unknown@supplier.test", subject="Hello", body="Do you sell snacks?")
+
+    assert env.state.scheduled_inbox == []
 
 
 def test_set_price_updates_slot():
@@ -152,14 +203,21 @@ def test_set_price_updates_slot():
 
 
 def test_summary():
-    """Test environment summary generation."""
+    """Test environment summary generation with email-based ordering."""
     env = VendingEnv()
 
-    # Set up some state
     env.state.storage_inventory["coke"] = 5
     env.state.storage_inventory["chips"] = 3
     env.restock("chips", 3, row=2, column=0)
-    env.place_order("water", 5)
+    env.queue_email(
+        recipient="sales@metrofoods.example",
+        subject="Order",
+        body=(
+            "Order 18 coke and 18 chocolate_bar for Springfield HQ.\n"
+            "Delivery address: 200 Industrial Way\n"
+            "Account: ACCT-999999"
+        ),
+    )
 
     summary = env.summary()
 
@@ -169,7 +227,7 @@ def test_summary():
     assert summary.machine_inventory["chips"] == 3
     totals = aggregate_sku_quantities(summary.machine_slots)
     assert totals["chips"] == 3
-    assert len(summary.outstanding_orders) == 1
+    assert len(summary.outstanding_orders) == 2
     assert summary.net_worth > 0
     assert summary.units_sold_total == 0
 
@@ -198,10 +256,9 @@ def test_bankruptcy_requires_grace_period():
 
     for day in range(9):
         env.end_of_day()
-        assert not env.state.bankrupt
-        assert env.state.negative_balance_days == day + 1
+
+    assert not env.state.bankrupt
 
     env.end_of_day()
 
     assert env.state.bankrupt
-    assert env.state.negative_balance_days == 10

--- a/tests/unit/vending_bench/test_performance.py
+++ b/tests/unit/vending_bench/test_performance.py
@@ -4,6 +4,13 @@ import time
 
 from examples.vending_bench import EnvConfig, VendingEnv
 
+SUPPLIER_EMAIL = "orders@rfd-inc.com"
+PURCHASE_TEMPLATE = (
+    "Please order 24 coke for next week delivery.\n"
+    "Delivery address: 500 Commerce Way\n"
+    "Account number: PERF-ACCT-01."
+)
+
 
 def test_2000_step_performance():
     """Test that 2000-step simulation completes within reasonable time."""
@@ -20,12 +27,16 @@ def test_2000_step_performance():
 
     # Run 2000 steps
     for step in range(2000):
-        # Occasionally place orders and restock
-        if step % 50 == 0 and env.state.cash_balance > 100:
+        # Occasionally request supplier orders via email and restock
+        if step % 50 == 0 and env.state.cash_balance > 200:
             try:
-                env.place_order("coke", 10)
+                env.queue_email(
+                    recipient=SUPPLIER_EMAIL,
+                    subject="Purchase Order",
+                    body=PURCHASE_TEMPLATE,
+                )
             except ValueError:
-                pass  # Might fail due to insufficient cash
+                pass  # May fail if cash falls below requirement mid-run
 
         if step % 30 == 0:
             # Restock from storage

--- a/tests/unit/vending_bench/test_tools.py
+++ b/tests/unit/vending_bench/test_tools.py
@@ -25,7 +25,6 @@ from examples.vending_bench.tools import (
     collect_cash,
     get_machine_inventory,
     physical_agent_tools,
-    place_order,
     read_email,
     restock_machine,
     send_email,
@@ -53,7 +52,6 @@ class TestToolParameterValidation:
             check_financial_status(),
             restock_machine(),
             set_price(),
-            place_order(),
             collect_cash(),
             wait_for_next_day(),
             ai_web_search(),
@@ -196,15 +194,6 @@ class TestToolIntegration:
         tool = get_machine_inventory()
         assert tool is not None
 
-    @patch("inspect_ai.util._store_model.store_as")
-    def test_place_order_insufficient_cash(self, mock_store_as, mock_env):
-        """Test order placement with insufficient cash."""
-        # Set low cash balance
-        mock_env.state.cash_balance = 1.0
-        mock_store_as.return_value = mock_env
-
-        tool = place_order()
-        assert tool is not None
 
     @patch("inspect_ai.util._store_model.store_as")
     def test_memory_tools_integration(self, mock_store_as, mock_memory):
@@ -240,9 +229,7 @@ class TestToolCollections:
         expected_tools = [
             "read_email",
             "send_email",
-            "check_inventory",
             "check_financial_status",
-            "place_order",
             "wait_for_next_day",
             "ai_web_search",
         ]
@@ -302,7 +289,7 @@ class TestToolCollections:
         }
 
         # Physical agent should not have access to high-level tools
-        forbidden_for_physical = {"place_order", "wait_for_next_day", "ai_web_search", "read_email", "send_email"}
+        forbidden_for_physical = {"wait_for_next_day", "ai_web_search", "read_email", "send_email"}
 
         physical_overlap = physical_names.intersection(forbidden_for_physical)
         assert len(physical_overlap) == 0, f"Physical agent has forbidden tools: {physical_overlap}"
@@ -370,7 +357,7 @@ class TestDeterministicBehavior:
         # Send email: 25 minutes
         # Restock: 75 minutes
         # Price change: 300 minutes (5 hours)
-        # Order placement: 25 minutes (email-based)
+        # Supplier emails still cost 25 minutes via send_email
         # Cash collection: 300 minutes (5 hours)
         # Web search: 60 minutes
 


### PR DESCRIPTION
## What & Why
Shift procurement to email-based supplier negotiations so the simulator mirrors
realistic ordering and payment timing. Removes the instant place_order tool in
favor of queued supplier confirmations.

**Scope**
Vending bench environment, supplier model, vending tools, and their tests. Other
bench components are unchanged.

## Changes
- Route queue_email through SupplierModel replies, debiting cash only after
  confirmed orders arrive the next morning.
- Extend SupplierModel with contact metadata, quote handling, MOQ validation,
  and deterministic lead-time scheduling.
- Enrich ai_web_search results with supplier catalogs and drop the
  place_order tool surface.

**Affected areas**
examples/vending_bench/, tests/unit/vending_bench/, tests/integration/
vending_bench/

## Risk & Rollback
**Risk checklist**
- [ ] Breaking change (compat plan described)
- [ ] Data migration/backfill (plan + window)
- [ ] Security/privacy change (perms/secrets/PII)
- [ ] Performance impact (baseline vs. new)
- [ ] Observability updated (metrics/logs/alerts)
- [ ] Feature flag (name, rollout, kill-switch tested)

**Rollback**
1. Revert commits 02bae0f and 7462505 from inspect-ai-rewrite.
2. Redeploy or rerun the simulator to restore place_order-driven procurement.

## Test Plan
**Automated**
- Unit: python -m pytest -q tests/unit/vending_bench
- Integration/E2E: python -m pytest -q tests/integration/vending_bench

**Manual / Evidence**
- Steps + expected signals: N/A
- UI (if applicable): N/A
- Performance (if applicable): N/A

## Follow-ups (optional)
- Track the upstream inspect_ai tool-call validation failures that block the
  broader pytest suite from going green.
