### PR TITLE
Ensure deterministic vending product generation and coverage

### DIFF
--- a/examples/vending_bench/config.py
+++ b/examples/vending_bench/config.py
@@ -68,6 +68,31 @@ def default_catalogue() -> dict[str, DemandProfile]:
     return {sku: DemandProfile(product=prod) for sku, prod in products.items()}
 
 
+def generate_new_product_parameters(product_name: str, seed: int) -> tuple[float, float, float, float]:
+    """Generate deterministic parameters for a new product based on name and seed.
+
+    Returns:
+        tuple: (unit_cost, base_price, base_daily_demand, price_elasticity)
+    """
+    import hashlib
+    import random
+
+    # Create deterministic seed from product name and environment seed
+    combined_seed_data = f"{seed}:new_product:{product_name}".encode()
+    digest = hashlib.sha256(combined_seed_data).digest()
+    product_seed = int.from_bytes(digest[:8], "big")
+
+    rng = random.Random(product_seed)
+
+    # Generate parameters within reasonable ranges
+    unit_cost = rng.uniform(0.30, 2.00)  # $0.30 to $2.00
+    base_price = unit_cost * rng.uniform(1.5, 3.0)  # 50-200% markup
+    base_daily_demand = rng.uniform(2.0, 8.0)  # 2-8 units per day base demand
+    price_elasticity = -rng.uniform(0.5, 1.5)  # Negative elasticity between -0.5 and -1.5
+
+    return unit_cost, base_price, base_daily_demand, price_elasticity
+
+
 @dataclass
 class EnvConfig:
     seed: int = 7

--- a/examples/vending_bench/env.py
+++ b/examples/vending_bench/env.py
@@ -6,7 +6,7 @@ import random
 from collections.abc import Iterable
 from dataclasses import dataclass
 
-from .config import EnvConfig
+from .config import EnvConfig, generate_new_product_parameters
 from .demand import DemandModel
 from .metrics import compute_net_worth, cumulative_units_sold, daily_report
 from .state import (
@@ -19,6 +19,7 @@ from .state import (
     DemandProfile,
     EmailMessage,
     Order,
+    Product,
     QueuedEmail,
     SimulatorState,
     Slot,
@@ -82,7 +83,8 @@ class VendingEnv:
     def _validate_row_for_product(self, row: int, product_sku: str) -> None:
         profile = self.state.demand_profiles.get(product_sku)
         if profile is None:
-            raise ValueError(f"Unknown SKU {product_sku}")
+            # Create new product dynamically if not found
+            profile = self._create_new_product(product_sku)
         size = profile.product.size
         if size == "small" and row not in SMALL_ITEM_ROWS:
             raise ValueError(f"SKU {product_sku} ({size}) must be placed in rows {SMALL_ITEM_ROWS}")
@@ -95,6 +97,49 @@ class VendingEnv:
             slot = Slot()
             self.state.machine_inventory[row][column] = slot
         return slot
+
+    def _create_new_product(self, sku: str) -> DemandProfile:
+        """Create a new product with deterministically generated parameters."""
+        # Generate parameters using environment seed and product name
+        unit_cost, base_price, base_daily_demand, price_elasticity = generate_new_product_parameters(
+            sku, self.config.seed
+        )
+
+        # Determine size and variety class based on SKU patterns
+        size = "large" if any(keyword in sku.lower() for keyword in ["chips", "energy", "large"]) else "small"
+        variety_class = (
+            "beverage"
+            if any(keyword in sku.lower() for keyword in ["drink", "water", "cola", "beverage", "juice"])
+            else "snack"
+        )
+        slot_capacity = 4 if size == "large" else 6
+
+        # Create product with generated parameters
+        product = Product(
+            sku=sku,
+            name=sku.replace("_", " ").title(),
+            size=size,
+            slot_capacity=slot_capacity,
+            unit_cost=unit_cost,
+            base_price=base_price,
+            base_daily_demand=base_daily_demand,
+            price_elasticity=price_elasticity,
+            variety_class=variety_class,
+        )
+
+        # Create demand profile and add to state
+        profile = DemandProfile(product=product)
+        self.state.demand_profiles[sku] = profile
+
+        # Ensure the demand model knows about this new product
+        self._demand.ensure_profiles({sku: profile})
+
+        # Ensure the supplier model knows about this new product
+        self._supplier._products[sku] = product
+        # Rebuild supplier contacts to include the new product
+        self._supplier._contacts = self._supplier._build_contacts()
+
+        return profile
 
     def advance_time(self, minutes: int | None = None) -> None:
         if minutes is None:
@@ -228,7 +273,8 @@ class VendingEnv:
 
         profile = self.state.demand_profiles.get(sku)
         if profile is None:
-            raise ValueError(f"Unknown SKU {sku}")
+            # Create new product dynamically if not found
+            profile = self._create_new_product(sku)
 
         self._demand.ensure_profiles({sku: profile})
 

--- a/tests/integration/vending_bench/test_determinism.py
+++ b/tests/integration/vending_bench/test_determinism.py
@@ -1,0 +1,276 @@
+"""Integration tests for deterministic behavior across the vending bench system."""
+
+from __future__ import annotations
+
+import pytest
+
+from examples.vending_bench import EnvConfig, VendingEnv
+
+
+def test_determinism_end_to_end_simulation():
+    """Test that complete simulation runs are deterministic with same seed."""
+    seed = 12345
+
+    def run_simulation(seed: int) -> dict:
+        """Run a complete simulation and return key metrics."""
+        config = EnvConfig(seed=seed, max_turns=50)  # Short run for testing
+        env = VendingEnv(config)
+
+        # Set up some initial inventory and pricing
+        env.state.storage_inventory["coke"] = 30
+        env.state.storage_inventory["chips"] = 20
+        env.restock("coke", 6, row=0, column=0)
+        env.restock("chips", 4, row=2, column=0)
+        env.set_price({(0, 0): 1.75, (2, 0): 2.25})
+
+        # Place an order to test supplier interactions
+        env.queue_email(
+            recipient="orders@rfd-inc.com",
+            subject="Purchase order",
+            body=(
+                "Please process the following purchase order:\n"
+                "- 24 coke\n"
+                "- 12 energy_drink\n"
+                "Delivery address: 100 Market St, Unit 5, Springfield\n"
+                "Account number: ACCT-123456\n"
+                "Thank you!"
+            ),
+        )
+
+        # Run simulation for multiple days
+        results = []
+        for turn in range(config.max_turns):
+            summary = env.summary()
+            results.append(
+                {
+                    "turn": turn,
+                    "day": summary.day,
+                    "cash_balance": summary.cash_balance,
+                    "cash_in_machine": summary.cash_in_machine,
+                    "units_sold_total": summary.units_sold_total,
+                    "net_worth": summary.net_worth,
+                    "storage_inventory": dict(summary.storage_inventory),
+                    "machine_inventory": dict(summary.machine_inventory),
+                    "outstanding_orders": len(summary.outstanding_orders),
+                }
+            )
+
+            if env.state.bankrupt:
+                break
+
+            env.advance_time()
+
+        return {
+            "final_results": results,
+            "total_turns": len(results),
+            "bankrupt": env.state.bankrupt,
+            "final_day": env.state.day,
+            "final_cash": env.state.cash_balance,
+            "final_net_worth": env.summary().net_worth,
+        }
+
+    # Run the simulation twice with the same seed
+    results1 = run_simulation(seed)
+    results2 = run_simulation(seed)
+
+    # The results should be identical
+    assert results1["total_turns"] == results2["total_turns"]
+    assert results1["bankrupt"] == results2["bankrupt"]
+    assert results1["final_day"] == results2["final_day"]
+    assert results1["final_cash"] == pytest.approx(results2["final_cash"])
+    assert results1["final_net_worth"] == pytest.approx(results2["final_net_worth"])
+
+    # Check that turn-by-turn results are identical
+    for turn_result1, turn_result2 in zip(results1["final_results"], results2["final_results"], strict=True):
+        assert turn_result1["turn"] == turn_result2["turn"]
+        assert turn_result1["day"] == turn_result2["day"]
+        assert turn_result1["cash_balance"] == pytest.approx(turn_result2["cash_balance"])
+        assert turn_result1["cash_in_machine"] == pytest.approx(turn_result2["cash_in_machine"])
+        assert turn_result1["units_sold_total"] == turn_result2["units_sold_total"]
+        assert turn_result1["net_worth"] == pytest.approx(turn_result2["net_worth"])
+        assert turn_result1["storage_inventory"] == turn_result2["storage_inventory"]
+        assert turn_result1["machine_inventory"] == turn_result2["machine_inventory"]
+        assert turn_result1["outstanding_orders"] == turn_result2["outstanding_orders"]
+
+
+def test_determinism_with_new_products():
+    """Test deterministic behavior when dynamically creating new products."""
+    seed = 54321
+
+    def run_with_new_products(seed: int) -> dict:
+        """Run simulation that creates new products during execution."""
+        config = EnvConfig(seed=seed, max_turns=20)
+        env = VendingEnv(config)
+
+        # Create several new products during the simulation
+        new_products = ["custom_soda", "premium_chips", "health_bar"]
+
+        results = []
+        for i, new_sku in enumerate(new_products):
+            # Add inventory and stock the new product
+            env.state.storage_inventory[new_sku] = 15
+
+            # Determine appropriate row based on product name
+            row = 2 if "chips" in new_sku else 0  # chips go in large rows
+            env.restock(new_sku, 3, row=row, column=i)
+
+            # Get the generated product parameters
+            profile = env.state.demand_profiles[new_sku]
+            results.append(
+                {
+                    "sku": new_sku,
+                    "unit_cost": profile.product.unit_cost,
+                    "base_price": profile.product.base_price,
+                    "base_daily_demand": profile.product.base_daily_demand,
+                    "price_elasticity": profile.product.price_elasticity,
+                    "size": profile.product.size,
+                    "variety_class": profile.product.variety_class,
+                }
+            )
+
+            # Run a few turns
+            for _ in range(3):
+                env.advance_time()
+
+        return {
+            "products": results,
+            "final_day": env.state.day,
+            "final_cash": env.state.cash_balance,
+        }
+
+    # Run twice with same seed
+    results1 = run_with_new_products(seed)
+    results2 = run_with_new_products(seed)
+
+    # New products should be identical
+    assert len(results1["products"]) == len(results2["products"])
+    for product1, product2 in zip(results1["products"], results2["products"], strict=True):
+        assert product1 == product2
+
+    # Final states should also be identical
+    assert results1["final_day"] == results2["final_day"]
+    assert results1["final_cash"] == pytest.approx(results2["final_cash"])
+
+
+def test_determinism_different_seeds_produce_different_results():
+    """Test that different seeds produce different simulation outcomes."""
+
+    def run_simulation(seed: int) -> dict:
+        """Run a simulation and return key outcomes."""
+        config = EnvConfig(seed=seed, max_turns=100)  # Longer run to ensure differences
+        env = VendingEnv(config)
+
+        # Set up initial conditions
+        env.state.storage_inventory["coke"] = 50
+        env.state.storage_inventory["chips"] = 30
+        env.restock("coke", 6, row=0, column=0)
+        env.restock("chips", 4, row=2, column=0)
+
+        # Run for multiple days to accumulate differences
+        daily_revenues = []
+        for _ in range(config.max_turns):
+            env.advance_time()
+            if env.state.bankrupt:
+                break
+
+            # Collect daily revenue if available
+            report = env.latest_report()
+            if report:
+                daily_revenues.append(report.revenue)
+
+        summary = env.summary()
+
+        return {
+            "final_cash": summary.cash_balance,
+            "final_units_sold": summary.units_sold_total,
+            "final_net_worth": summary.net_worth,
+            "daily_revenues": daily_revenues,
+            "total_turns": env.state.turns,
+        }
+
+    # Run with different seeds
+    results_seed1 = run_simulation(1111)
+    results_seed2 = run_simulation(2222)
+
+    # Results should be different (with very high probability)
+    # Check multiple metrics for differences
+    differences = [
+        results_seed1["final_cash"] != results_seed2["final_cash"],
+        results_seed1["final_units_sold"] != results_seed2["final_units_sold"],
+        results_seed1["final_net_worth"] != results_seed2["final_net_worth"],
+        results_seed1["daily_revenues"] != results_seed2["daily_revenues"],
+    ]
+
+    assert any(differences), (
+        f"Different seeds should produce different results. Results1: {results_seed1}, Results2: {results_seed2}"
+    )
+
+
+def test_determinism_supplier_email_workflows():
+    """Test that supplier email interactions are deterministic."""
+    seed = 99999
+
+    def run_supplier_test(seed: int) -> dict:
+        """Test supplier interactions and return outcomes."""
+        config = EnvConfig(seed=seed)
+        env = VendingEnv(config)
+
+        results = []
+
+        # Test quote requests
+        env.queue_email(
+            recipient="supply@quickstock.com",
+            subject="Quote request",
+            body="Please send your current pricing catalog.",
+        )
+
+        env.end_of_day()  # Process scheduled emails
+
+        quote_emails = [msg for msg in env.state.inbox if msg.sender == "supply@quickstock.com"]
+        results.append(
+            {
+                "type": "quote",
+                "count": len(quote_emails),
+                "body_length": len(quote_emails[0].body) if quote_emails else 0,
+            }
+        )
+
+        # Test purchase orders
+        env.queue_email(
+            recipient="orders@rfd-inc.com",
+            subject="Purchase order",
+            body=("Order request:\n- 24 coke\n- 12 energy_drink\nDelivery address: 123 Test St\nAccount: ACCT-999\n"),
+        )
+
+        order_count_before = len(env.state.outstanding_orders)
+        cash_before = env.state.cash_balance
+
+        # Orders should be created immediately
+        order_count_after = len(env.state.outstanding_orders)
+        cash_after = env.state.cash_balance
+
+        results.append(
+            {
+                "type": "purchase",
+                "orders_created": order_count_after - order_count_before,
+                "cash_spent": cash_before - cash_after,
+            }
+        )
+
+        # Get delivery days for orders
+        delivery_days = [order.delivery_day for order in env.state.outstanding_orders]
+        results.append(
+            {
+                "type": "deliveries",
+                "delivery_days": sorted(delivery_days),
+            }
+        )
+
+        return {"interactions": results}
+
+    # Run twice with same seed
+    results1 = run_supplier_test(seed)
+    results2 = run_supplier_test(seed)
+
+    # All supplier interactions should be identical
+    assert results1 == results2

--- a/tests/unit/vending_bench/test_demand.py
+++ b/tests/unit/vending_bench/test_demand.py
@@ -110,3 +110,137 @@ def test_variety_penalty_excess_categories():
     assert penalty_low == pytest.approx(1.0)
     assert penalty_high == pytest.approx(0.75)
     assert 0.5 <= penalty_high < penalty_low
+
+
+def test_new_product_parameter_generation_deterministic():
+    """Test that new product parameters are deterministic with same seed."""
+    from examples.vending_bench.config import generate_new_product_parameters
+
+    seed = 12345
+    product_name = "test_new_product"
+
+    # Generate parameters multiple times with same seed
+    params1 = generate_new_product_parameters(product_name, seed)
+    params2 = generate_new_product_parameters(product_name, seed)
+    params3 = generate_new_product_parameters(product_name, seed)
+
+    assert params1 == params2 == params3
+
+    # Verify parameters are within expected ranges
+    unit_cost, base_price, base_daily_demand, price_elasticity = params1
+    assert 0.30 <= unit_cost <= 2.00
+    assert base_price >= unit_cost * 1.5
+    assert base_price <= unit_cost * 3.0
+    assert 2.0 <= base_daily_demand <= 8.0
+    assert -1.5 <= price_elasticity <= -0.5
+
+
+def test_new_product_parameter_generation_varies_by_name():
+    """Test that different product names generate different parameters."""
+    from examples.vending_bench.config import generate_new_product_parameters
+
+    seed = 12345
+    params_a = generate_new_product_parameters("product_a", seed)
+    params_b = generate_new_product_parameters("product_b", seed)
+
+    assert params_a != params_b
+
+
+def test_new_product_parameter_generation_varies_by_seed():
+    """Test that different seeds generate different parameters."""
+    from examples.vending_bench.config import generate_new_product_parameters
+
+    product_name = "test_product"
+    params_seed1 = generate_new_product_parameters(product_name, 111)
+    params_seed2 = generate_new_product_parameters(product_name, 222)
+
+    assert params_seed1 != params_seed2
+
+
+def test_demand_model_weather_caching_deterministic():
+    """Test that weather factors are cached and deterministic."""
+    model = DemandModel(seed=42, skus=[])
+
+    # Weather should be the same for the same day
+    weather1 = model._weather_factor(day=5, sensitivity=0.3)
+    weather2 = model._weather_factor(day=5, sensitivity=0.3)
+    assert weather1 == weather2
+
+    # Different days should have different weather
+    weather3 = model._weather_factor(day=6, sensitivity=0.3)
+    assert weather1 != weather3
+
+
+def test_demand_model_noise_caching_deterministic():
+    """Test that noise factors are cached and deterministic."""
+    model = DemandModel(seed=42, skus=["test_sku"])
+
+    # Noise should be the same for the same day and SKU
+    noise1 = model._noise(day=3, sku="test_sku", scale=0.2)
+    noise2 = model._noise(day=3, sku="test_sku", scale=0.2)
+    assert noise1 == noise2
+
+    # Different days should have different noise
+    noise3 = model._noise(day=4, sku="test_sku", scale=0.2)
+    assert noise1 != noise3
+
+    # Different SKUs should have different noise
+    noise4 = model._noise(day=3, sku="other_sku", scale=0.2)
+    assert noise1 != noise4
+
+
+def test_demand_simulation_deterministic_multiple_runs():
+    """Test that demand simulation produces identical results across multiple runs."""
+    product = _build_product(sku="consistent_sku")
+    profile = DemandProfile(
+        product=product,
+        reference_price=2.0,
+        base_daily_sales=10.0,
+        price_elasticity=-1.0,
+        noise_scale=0.1,
+        weather_sensitivity=0.1,
+        seasonal_amplitude=0.05,
+    )
+
+    # Create two identical demand models
+    model1 = DemandModel(seed=789, skus=[product.sku])
+    model2 = DemandModel(seed=789, skus=[product.sku])
+
+    # Set up identical machine state
+    machine_inventory = [[None for _ in range(3)] for _ in range(4)]
+    machine_inventory[0][0] = Slot(
+        sku=product.sku,
+        quantity=10,
+        price=2.0,
+        capacity=product.slot_capacity,
+    )
+
+    # Run simulation on both models
+    outcome1 = model1.simulate_day(
+        day=10,
+        demand_profiles={product.sku: profile},
+        machine_inventory=machine_inventory,
+    )
+
+    # Reset machine state for second run
+    machine_inventory[0][0] = Slot(
+        sku=product.sku,
+        quantity=10,
+        price=2.0,
+        capacity=product.slot_capacity,
+    )
+
+    outcome2 = model2.simulate_day(
+        day=10,
+        demand_profiles={product.sku: profile},
+        machine_inventory=machine_inventory,
+    )
+
+    # Results should be identical
+    assert outcome1.units_sold == outcome2.units_sold
+    assert outcome1.revenue == pytest.approx(outcome2.revenue)
+    assert len(outcome1.slot_sales) == len(outcome2.slot_sales)
+    for slot_key in outcome1.slot_sales:
+        assert slot_key in outcome2.slot_sales
+        assert outcome1.slot_sales[slot_key].quantity == outcome2.slot_sales[slot_key].quantity
+        assert outcome1.slot_sales[slot_key].revenue == pytest.approx(outcome2.slot_sales[slot_key].revenue)

--- a/tests/unit/vending_bench/test_env.py
+++ b/tests/unit/vending_bench/test_env.py
@@ -262,3 +262,152 @@ def test_bankruptcy_requires_grace_period():
     env.end_of_day()
 
     assert env.state.bankrupt
+
+
+def test_new_product_creation_deterministic():
+    """Test that new product creation is deterministic with same seed."""
+    config1 = EnvConfig(seed=123)
+    config2 = EnvConfig(seed=123)
+
+    env1 = VendingEnv(config1)
+    env2 = VendingEnv(config2)
+
+    # Create a new product that doesn't exist in default catalog
+    new_sku = "test_new_soda"
+
+    # Add storage inventory
+    env1.state.storage_inventory[new_sku] = 10
+    env2.state.storage_inventory[new_sku] = 10
+
+    # Trigger product creation by restocking
+    env1.restock(new_sku, 5, row=0, column=0)
+    env2.restock(new_sku, 5, row=0, column=0)
+
+    # Both should have created identical products
+    profile1 = env1.state.demand_profiles[new_sku]
+    profile2 = env2.state.demand_profiles[new_sku]
+
+    assert profile1.product.unit_cost == profile2.product.unit_cost
+    assert profile1.product.base_price == profile2.product.base_price
+    assert profile1.product.base_daily_demand == profile2.product.base_daily_demand
+    assert profile1.product.price_elasticity == profile2.product.price_elasticity
+    assert profile1.product.size == profile2.product.size
+    assert profile1.product.variety_class == profile2.product.variety_class
+
+    # Both supplier models should know about the new product
+    directory1 = env1._supplier.supplier_directory()
+    directory2 = env2._supplier.supplier_directory()
+
+    metro1 = directory1.get("sales@metrofoods.example")
+    metro2 = directory2.get("sales@metrofoods.example")
+
+    assert metro1 and metro2
+    assert new_sku in metro1.products
+    assert new_sku in metro2.products
+
+    # Offers should be identical
+    offer1 = metro1.products[new_sku]
+    offer2 = metro2.products[new_sku]
+
+    assert offer1.wholesale_price == offer2.wholesale_price
+    assert offer1.min_order_quantity == offer2.min_order_quantity
+    assert offer1.lead_time_days == offer2.lead_time_days
+
+
+def test_supplier_lead_times_deterministic():
+    """Test that supplier lead times are deterministic with same seed."""
+    config1 = EnvConfig(seed=456)
+    config2 = EnvConfig(seed=456)
+
+    env1 = VendingEnv(config1)
+    env2 = VendingEnv(config2)
+
+    body = _purchase_order_body()
+
+    # Place identical orders
+    env1.queue_email(recipient=SUPPLIER_EMAIL, subject="Purchase order", body=body)
+    env2.queue_email(recipient=SUPPLIER_EMAIL, subject="Purchase order", body=body)
+
+    # Lead times should be identical
+    orders1 = env1.state.outstanding_orders
+    orders2 = env2.state.outstanding_orders
+
+    assert len(orders1) == len(orders2)
+    for order1, order2 in zip(orders1, orders2, strict=True):
+        assert order1.delivery_day == order2.delivery_day
+        assert order1.sku == order2.sku
+        assert order1.quantity == order2.quantity
+        assert order1.unit_cost == pytest.approx(order2.unit_cost)
+
+
+def test_full_environment_deterministic_multiple_days():
+    """Test that complete environment behavior is deterministic across multiple days."""
+    config1 = EnvConfig(seed=789)
+    config2 = EnvConfig(seed=789)
+
+    env1 = VendingEnv(config1)
+    env2 = VendingEnv(config2)
+
+    # Set up identical starting conditions
+    for env in [env1, env2]:
+        env.state.storage_inventory["coke"] = 20
+        env.state.storage_inventory["chips"] = 15
+        env.restock("coke", 6, row=0, column=0)
+        env.restock("chips", 4, row=2, column=0)
+        env.set_price({(0, 0): 1.75, (2, 0): 2.00})
+
+    # Run simulation for several days
+    for day in range(3):
+        # Daily reports should be identical (except for object IDs)
+        report1 = env1.latest_report()
+        report2 = env2.latest_report()
+
+        if report1 and report2:
+            assert report1.day == report2.day
+            assert report1.revenue == pytest.approx(report2.revenue)
+            assert report1.cash_balance == pytest.approx(report2.cash_balance)
+            assert report1.units_sold == report2.units_sold
+
+        # Advance time should produce identical results
+        env1.advance_time(1440)  # Full day
+        env2.advance_time(1440)
+
+    # Final states should be identical
+    final_summary1 = env1.summary()
+    final_summary2 = env2.summary()
+
+    assert final_summary1.day == final_summary2.day
+    assert final_summary1.cash_balance == pytest.approx(final_summary2.cash_balance)
+    assert final_summary1.cash_in_machine == pytest.approx(final_summary2.cash_in_machine)
+    assert final_summary1.storage_inventory == final_summary2.storage_inventory
+    assert final_summary1.machine_inventory == final_summary2.machine_inventory
+    assert final_summary1.units_sold_total == final_summary2.units_sold_total
+
+
+def test_seed_parameter_isolation():
+    """Test that changing seed produces different behaviors."""
+    config1 = EnvConfig(seed=111)
+    config2 = EnvConfig(seed=222)
+
+    env1 = VendingEnv(config1)
+    env2 = VendingEnv(config2)
+
+    # Set up identical starting conditions
+    for env in [env1, env2]:
+        env.state.storage_inventory["coke"] = 20
+        env.restock("coke", 6, row=0, column=0)
+
+    # Run for one day
+    env1.advance_time(1440)
+    env2.advance_time(1440)
+
+    # Results should be different (with high probability)
+    # While we can't guarantee all values will be different,
+    # at least some should be due to randomness in demand simulation
+    report1 = env1.latest_report()
+    report2 = env2.latest_report()
+
+    # Revenue is most likely to differ due to demand noise/weather
+    if report1 and report2:
+        # Allow for small chance they're the same, but very unlikely
+        assert report1.revenue != report2.revenue or report1.units_sold != report2.units_sold


### PR DESCRIPTION
## What & Why
  Ensure vending simulations stay reproducible when agents encounter unknown SKUs by deterministically generating product parameters and wiring the flow through the environment and supplier
  paths.【F:examples/vending_bench/config.py-L71-L93】【F:examples/vending_bench/env.py-L83-L142】

  **Scope**
  Out of scope: modifying existing supplier pricing logic or broader catalog defaults.

  ## Changes
  - Add `generate_new_product_parameters()` and invoke it from `VendingEnv` so new SKUs get deterministic cost, pricing, and demand traits seeded by environment configuration.【F:examples/
  vending_bench/config.py-L71-L93】【F:examples/vending_bench/env.py-L83-L142】
  - Extend unit tests to pin determinism for parameter generation, weather/noise caching, and demand simulation outcomes.【F:tests/unit/vending_bench/test_demand.py-L115-L246】
  - Add environment-level and supplier integration tests plus end-to-end determinism coverage across multi-day runs and dynamic product creation workflows.【F:tests/unit/vending_bench/
  test_env.py-L267-L413】【F:tests/integration/vending_bench/test_determinism.py-L1-L276】

  **Affected areas**
  - `examples/vending_bench/`
  - `tests/unit/vending_bench/`
  - `tests/integration/vending_bench/`

  ## Risk & Rollback
  **Risk checklist**
  - [ ] Breaking change (compat plan described)
  - [ ] Data migration/backfill (plan + window)
  - [ ] Security/privacy change (perms/secrets/PII)
  - [ ] Performance impact (baseline vs. new)
  - [ ] Observability updated (metrics/logs/alerts)
  - [ ] Feature flag (name, rollout, kill-switch tested)

  **Rollback**
  Revert the four commits (or `git revert 3582403..HEAD`) to remove deterministic creation and associated tests; restores prior behavior where unknown SKUs raise instead of being
  synthesized.

  ## Test Plan
  **Automated**
  - Unit: `CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai uv run pytest -q tests/unit/vending_bench/test_demand.py` (new deterministic parameter tests)【F:tests/unit/vending_bench/
  test_demand.py-L115-L246】
  - Integration/E2E: `CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai uv run pytest -q tests/unit/vending_bench/test_env.py tests/integration/vending_bench/test_determinism.py`
  (environment + full-run determinism)【F:tests/unit/vending_bench/test_env.py-L267-L413】【F:tests/integration/vending_bench/test_determinism.py-L1-L276】

  **Manual / Evidence**
  - Steps + expected signals: N/A (automated coverage only)
  - UI: N/A
  - Performance: Determinism tests implicitly validate repeatability; no additional perf sampling

  ## Follow-ups (optional)
  - None
