### PR TITLE
Fix set_price clarification flow and stabilize integration tests

### DIFF
--- a/examples/vending_bench/tools.py
+++ b/examples/vending_bench/tools.py
@@ -706,11 +706,16 @@ def set_price() -> Tool:
         """
 
         if not updates:
-            raise ValueError("updates must not be empty")
+            raise ToolException("At least one price update is required. Please provide the slot row, column, and target price.")
 
+        validated_updates: list[SlotPriceUpdate] = []
         for update in updates:
-            if update.price <= 0:
-                raise ValueError("price must be positive")
+            row = _require_positive_int("row", update.row)
+            column = _require_positive_int("column", update.column)
+            price = _require_positive_float("price", update.price)
+            validated_updates.append(SlotPriceUpdate(row=row, column=column, price=price))
+
+        updates = validated_updates
 
         t0 = _log_tool_event(
             name="set_price",

--- a/tests/integration/inspect_agents/test_handoff_exclusive_end_to_end.py
+++ b/tests/integration/inspect_agents/test_handoff_exclusive_end_to_end.py
@@ -12,6 +12,7 @@ Notes:
 """
 
 import asyncio
+from dataclasses import asdict
 
 import pytest
 
@@ -79,9 +80,9 @@ def test_handoff_exclusive_one_handoff_n_skipped(monkeypatch):
         ChatMessageAssistant(
             content="",
             tool_calls=[
-                ToolCall(id="1", function="transfer_to_reader", arguments={}),
-                ToolCall(id="2", function="echo_a", arguments={}),
-                ToolCall(id="3", function="echo_b", arguments={}),
+                asdict(ToolCall(id="1", function="transfer_to_reader", arguments={})),
+                asdict(ToolCall(id="2", function="echo_a", arguments={})),
+                asdict(ToolCall(id="3", function="echo_b", arguments={})),
             ],
         ),
     ]

--- a/tests/integration/inspect_agents/test_handoff_exclusivity_integration.py
+++ b/tests/integration/inspect_agents/test_handoff_exclusivity_integration.py
@@ -11,9 +11,9 @@ dev/prod preset gates) to validate core semantics with the real policy engine.
 
 import asyncio
 import sys
+from dataclasses import asdict
 
 import pytest
-from dataclasses import asdict
 
 pytestmark = pytest.mark.handoff
 

--- a/tests/integration/inspect_agents/test_handoff_exclusivity_integration.py
+++ b/tests/integration/inspect_agents/test_handoff_exclusivity_integration.py
@@ -13,6 +13,7 @@ import asyncio
 import sys
 
 import pytest
+from dataclasses import asdict
 
 pytestmark = pytest.mark.handoff
 
@@ -52,7 +53,7 @@ def test_policy_approver_enforces_exclusivity_on_mixed_batch():
         ToolCall(id="2", function="transfer_to_writer", arguments={}),
         ToolCall(id="3", function="read_file", arguments={"file_path": "README.md"}),
     ]
-    msg = ChatMessageAssistant(content="", tool_calls=calls)
+    msg = ChatMessageAssistant(content="", tool_calls=[asdict(call) for call in calls])
     history = [msg]
 
     # First handoff approved

--- a/tests/integration/inspect_agents/test_kill_switch_end_to_end.py
+++ b/tests/integration/inspect_agents/test_kill_switch_end_to_end.py
@@ -7,6 +7,7 @@ subsequent tools are rejected, with standardized transcript events emitted.
 """
 
 import asyncio
+from dataclasses import asdict
 import sys
 import types
 
@@ -108,8 +109,8 @@ def test_kill_switch_only_first_tool_executes(monkeypatch):
         ChatMessageAssistant(
             content="",
             tool_calls=[
-                ToolCall(id="1", function="echo_a", arguments={}),
-                ToolCall(id="2", function="echo_b", arguments={}),
+                asdict(ToolCall(id="1", function="echo_a", arguments={})),
+                asdict(ToolCall(id="2", function="echo_b", arguments={})),
             ],
         ),
     ]

--- a/tests/integration/inspect_agents/test_kill_switch_end_to_end.py
+++ b/tests/integration/inspect_agents/test_kill_switch_end_to_end.py
@@ -7,9 +7,9 @@ subsequent tools are rejected, with standardized transcript events emitted.
 """
 
 import asyncio
-from dataclasses import asdict
 import sys
 import types
+from dataclasses import asdict
 
 import pytest
 

--- a/tests/integration/inspect_agents/test_parallel_kill_switch.py
+++ b/tests/integration/inspect_agents/test_parallel_kill_switch.py
@@ -3,6 +3,7 @@
 import asyncio
 import importlib
 import logging
+from dataclasses import asdict
 
 import pytest
 
@@ -38,8 +39,8 @@ def test_kill_switch_logs_skips_and_rejects_subsequent_calls(monkeypatch, caplog
     msg = ChatMessageAssistant(
         content="",
         tool_calls=[
-            ToolCall(id="1", function="echo_a", arguments={}),
-            ToolCall(id="2", function="echo_b", arguments={}),
+            asdict(ToolCall(id="1", function="echo_a", arguments={})),
+            asdict(ToolCall(id="2", function="echo_b", arguments={})),
         ],
     )
     history = [msg]
@@ -95,7 +96,7 @@ def test_kill_switch_escalates_when_handoff_present(monkeypatch, caplog):
     # One handoff + one non-handoff in the same assistant message
     handoff = ToolCall(id="h1", function="transfer_to_delegate", arguments={})
     other = ToolCall(id="2", function="echo_b", arguments={})
-    msg = ChatMessageAssistant(content="", tool_calls=[handoff, other])
+    msg = ChatMessageAssistant(content="", tool_calls=[asdict(handoff), asdict(other)])
     history = [msg]
 
     caplog.set_level(logging.INFO, logger="inspect_agents.tools")

--- a/tests/integration/inspect_agents/test_tool_timeouts.py
+++ b/tests/integration/inspect_agents/test_tool_timeouts.py
@@ -116,12 +116,14 @@ def test_sandbox_text_editor_timeout_integration(monkeypatch):
     original_fs_mode = os.environ.get("INSPECT_AGENTS_FS_MODE")
     os.environ["INSPECT_AGENTS_FS_MODE"] = "sandbox"
 
-    # Constrain sandbox root to a temp dir and target a file within it
+    # Constrain sandbox root to a temp dir and allow writes during the test
     import tempfile
 
     tmp_dir = tempfile.mkdtemp(prefix="inspect-agents-sbx-")
     original_fs_root = os.environ.get("INSPECT_AGENTS_FS_ROOT")
     os.environ["INSPECT_AGENTS_FS_ROOT"] = tmp_dir
+    original_fs_read_only = os.environ.get("INSPECT_AGENTS_FS_READ_ONLY")
+    os.environ["INSPECT_AGENTS_FS_READ_ONLY"] = "0"
     file_path = os.path.join(tmp_dir, "test.txt")
 
     try:
@@ -165,3 +167,8 @@ def test_sandbox_text_editor_timeout_integration(monkeypatch):
             os.environ["INSPECT_AGENTS_FS_ROOT"] = original_fs_root
         else:
             os.environ.pop("INSPECT_AGENTS_FS_ROOT", None)
+
+        if original_fs_read_only is not None:
+            os.environ["INSPECT_AGENTS_FS_READ_ONLY"] = original_fs_read_only
+        else:
+            os.environ.pop("INSPECT_AGENTS_FS_READ_ONLY", None)

--- a/tests/integration/vending_bench/test_clarification_loop.py
+++ b/tests/integration/vending_bench/test_clarification_loop.py
@@ -222,14 +222,14 @@ class TestSetPriceClarificationLoop:
     """Test clarification loop for set_price tool."""
 
     def test_set_price_empty_updates_triggers_exception(self, vending_tools_module, mock_env):
-        """Test that empty updates list triggers ValueError."""
+        """ToolException clarifies when no price updates are provided."""
         with patch("examples.vending_bench.tools.get_env", return_value=mock_env):
             price_tool = vending_tools_module.set_price()
 
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(ToolException) as exc_info:
                 price_tool(updates=[])
 
-            assert "updates must not be empty" in str(exc_info.value)
+            assert "At least one price update is required" in str(exc_info.value)
 
     def test_set_price_empty_slot_triggers_exception(self, vending_tools_module, mock_env):
         """Test that updating an empty slot triggers ToolException."""
@@ -243,15 +243,15 @@ class TestSetPriceClarificationLoop:
             assert "slot (2, 2) is empty" in str(exc_info.value)
 
     def test_set_price_negative_price_triggers_exception(self, vending_tools_module, mock_env):
-        """Test that negative price triggers ValueError."""
+        """ToolException clarifies when price is non-positive."""
         with patch("examples.vending_bench.tools.get_env", return_value=mock_env):
             price_tool = vending_tools_module.set_price()
             updates = [SlotPriceUpdate(row=1, column=1, price=-1.50)]
 
-            with pytest.raises(ValueError) as exc_info:
+            with pytest.raises(ToolException) as exc_info:
                 price_tool(updates=updates)
 
-            assert "price must be positive" in str(exc_info.value)
+            assert "price must be greater than zero" in str(exc_info.value)
 
     def test_set_price_successful_flow(self, vending_tools_module, mock_env):
         """Test that valid set_price parameters succeed."""

--- a/tests/unit/vending_bench/test_tools.py
+++ b/tests/unit/vending_bench/test_tools.py
@@ -33,7 +33,6 @@ from examples.vending_bench.tools import (
     supervisor_tools,
     wait_for_next_day,
 )
-
 from inspect_agents.exceptions import ToolException
 
 

--- a/tests/unit/vending_bench/test_tools.py
+++ b/tests/unit/vending_bench/test_tools.py
@@ -17,6 +17,7 @@ from examples.vending_bench.memory import (
     vector_search,
 )
 from examples.vending_bench.tools import (
+    SlotPriceUpdate,
     ai_web_search,
     check_financial_status,
     check_inventory,
@@ -32,6 +33,8 @@ from examples.vending_bench.tools import (
     supervisor_tools,
     wait_for_next_day,
 )
+
+from inspect_agents.exceptions import ToolException
 
 
 class TestToolParameterValidation:
@@ -185,6 +188,37 @@ class TestToolIntegration:
 
         tool = set_price()
         assert tool is not None
+
+    def test_set_price_requires_updates(self):
+        """Tool should prompt for updates when none are provided."""
+
+        tool = set_price()
+
+        with pytest.raises(ToolException) as excinfo:
+            tool([])
+
+        assert "At least one price update is required" in str(excinfo.value)
+
+    def test_set_price_rejects_non_positive_price(self):
+        """Tool should clarify when price is non-positive."""
+
+        tool = set_price()
+        updates = [SlotPriceUpdate(row=1, column=1, price=0.0)]
+
+        with pytest.raises(ToolException) as excinfo:
+            tool(updates)
+
+        assert "price must be greater than zero" in str(excinfo.value)
+
+    def test_set_price_rejects_invalid_coordinates(self):
+        """Tool should clarify when slot coordinates are invalid."""
+
+        tool = set_price()
+
+        with pytest.raises(ToolException) as excinfo:
+            tool([SlotPriceUpdate(row=0, column=1, price=1.0)])
+
+        assert "row must be greater than zero" in str(excinfo.value)
 
     @patch("inspect_ai.util._store_model.store_as")
     def test_get_machine_inventory_tool(self, mock_store_as, mock_env):


### PR DESCRIPTION
## What & Why

  Aligns the vending bench set_price tool with the ToolException-based clarification loop so malformed payloads prompt follow-up questions instead of surfacing raw ValueErrors. Also fixes
  approval and sandbox timeout integration tests to reflect the updated validation behavior and current Inspect-AI Pydantic requirements.

  Scope

  - Vending bench price-setting tool and its unit/integration coverage
  - Approval policy integration tests constructing assistant tool calls
  - Sandbox text-editor timeout integration harness
  - Out of scope: broader approval policy behavior, full test-suite stabilization

  ## Changes

  - Replaced set_price ValueErrors with helper-driven ToolExceptions, normalizing slot and price validation ahead of environment calls
  - Added unit/integration tests asserting clarifying messages for empty updates, invalid coordinates, and non-positive prices
  - Serialized approval integration test tool calls via dataclasses.asdict to satisfy vendored Pydantic assistant message parsing
  - Ensured sandbox timeout integration temporarily disables read-only mode while using slow text-editor stubs

  Affected areas

  - examples/vending_bench/tools.py
  - tests/unit/vending_bench/test_tools.py
  - tests/integration/vending_bench/test_clarification_loop.py
  - tests/integration/inspect_agents/test_handoff_exclusive_end_to_end.py
  - tests/integration/inspect_agents/test_handoff_exclusivity_integration.py
  - tests/integration/inspect_agents/test_kill_switch_end_to_end.py
  - tests/integration/inspect_agents/test_parallel_kill_switch.py
  - tests/integration/inspect_agents/test_tool_timeouts.py

  ## Risk & Rollback

  Risk checklist

  - [ ] Breaking change (compat plan described)
  - [ ] Data migration/backfill (plan + window)
  - [ ] Security/privacy change (perms/secrets/PII)
  - [ ] Performance impact (baseline vs. new)
  - [ ] Observability updated (metrics/logs/alerts)
  - [ ] Feature flag (name, rollout, kill-switch tested)

  Rollback
  Revert the three commits in this branch; no data migrations or config toggles are required.

  ## Test Plan

  Automated

  - Unit: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python -m pytest -q tests/unit/vending_bench/test_tools.py -k set_price
  - Integration/E2E:
      - CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python -m pytest -q tests/integration/vending_bench/test_clarification_loop.py -k set_price
      - CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python -m pytest -q tests/integration/inspect_agents/test_handoff_exclusive_end_to_end.py tests/integration/inspect_agents/
  test_handoff_exclusivity_integration.py tests/integration/inspect_agents/test_kill_switch_end_to_end.py tests/integration/inspect_agents/test_parallel_kill_switch.py
      - CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai python -m pytest -q tests/integration/inspect_agents/test_tool_timeouts.py -k sandbox_text_editor_timeout_integration

  Manual / Evidence

  - Steps + expected signals: Not applicable; behavior validated via automated tests
  - UI (if applicable): Not applicable
  - Performance (if applicable): Not applicable

  ## Follow-ups (optional)

  - Run the full tests/unit tests/integration sweep once other legacy failures are triaged to confirm whole-suite green
