### PR TITLE
feat+docs: add GPT demand provider with coverage

### DIFF
--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -224,6 +224,10 @@ References
   - OpenAI‑compatible vendors via `openai-api/<vendor>` also use
     `<VENDOR>_API_KEY` and `<VENDOR>_MODEL` (e.g., `LM_STUDIO_*`).
 
+- Demand parameter generation
+  - `DEMAND_PROVIDER` — `llm` (GPT-4o) or `deterministic` (legacy RNG). Defaults to `llm`; falls back automatically when the LLM client is unavailable.
+  - `DEMAND_LLM_MODEL` — optional override for the GPT model used by demand estimation (default `gpt-4o`).
+
 !!! note "Upstream Inspect‑AI environment variables"
     Some environment variables are defined and consumed by the upstream Inspect‑AI CLI/runtime rather than this repository. Common examples include:
 

--- a/examples/vending_bench/README.md
+++ b/examples/vending_bench/README.md
@@ -76,10 +76,20 @@ uv run pytest -q tests/unit/vending_bench -k mirror_sync
 Key configuration options in `examples/vending_bench/config.py`:
 
 - `seed`: Deterministic seed for reproducible runs
-- `max_days`: Episode length limit
 - `starting_cash`: Initial capital
 - `daily_fee`: Operating cost per day
-- `memory_budget`: Context window management
+- `slots_small` / `slots_large`: Machine layout dimensions
+- `minutes_per_turn`: Simulation step size
+- `demand_provider`: Demand parameter provider (`llm` or `deterministic`, defaults to `llm` with automatic fallback)
+
+### Demand Parameter Providers
+
+The simulator now supports pluggable demand parameter providers:
+
+- `DEMAND_PROVIDER` (env var) selects `llm` (GPT-4o) or `deterministic` (legacy RNG). When unset, `llm` is attempted first.
+- `DEMAND_LLM_MODEL` (optional) overrides the GPT model name (defaults to `gpt-4o`).
+- GPT responses return JSON containing `reference_price`, `base_sales`, and `elasticity` as defined by a strict schema; raw responses (including the seed used) are logged at `INFO` for auditability.
+- If the LLM client is unavailable or returns invalid data, the deterministic provider is used as a safe fallback. A single set of parameters is cached per SKU and reused for all days.
 
 ## Evaluation Metrics
 

--- a/examples/vending_bench/README.md
+++ b/examples/vending_bench/README.md
@@ -80,6 +80,24 @@ Key configuration options in `examples/vending_bench/config.py`:
 - `starting_cash`: Initial capital
 - `daily_fee`: Operating cost per day
 - `memory_budget`: Context window management
+- `supplier`: `SupplierConfig` controlling minimum and maximum shipping lead times
+- `supplier_research_minutes`: Minutes advanced when the supervisor agent performs supplier research
+
+## Supplier Integrations
+
+Live supplier realism relies on external APIs. Configure the following environment variables when running with
+real integrations:
+
+- `PERPLEXITY_API_KEY` (optional): Enables Perplexity Chat Completions for supplier discovery. Override the model
+  with `PERPLEXITY_MODEL` if needed.
+- `OPENAI_API_KEY` (optional): Enables GPT-4o for grounded supplier email replies. Override the model with
+  `VENDING_SUPPLIER_GPT_MODEL` (defaults to `gpt-4o-mini`).
+- `VENDING_SUPPLIER_FORCE_STUB` (optional): Set to `1` to force deterministic stub mode even when credentials are
+  available—useful for offline CI runs.
+
+When credentials are not present the simulator automatically falls back to deterministic stub behaviour, preserving
+reproducibility. Live mode registers suppliers returned by Perplexity, grounds GPT replies on those results, and
+maintains 2–5 day delivery lead times consistent with the benchmark specification.
 
 ## Evaluation Metrics
 

--- a/examples/vending_bench/config.py
+++ b/examples/vending_bench/config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from .state import DemandProfile, Product
+from .supplier import SupplierConfig
 
 
 def default_catalogue() -> dict[str, DemandProfile]:
@@ -103,6 +104,8 @@ class EnvConfig:
     max_turns: int = 2000
     minutes_per_turn: int = 60
     catalogue: dict[str, DemandProfile] = field(default_factory=default_catalogue)
+    supplier: SupplierConfig = field(default_factory=SupplierConfig)
+    supplier_research_minutes: int = 60
 
     def validate(self) -> None:
         if self.starting_cash < 0:
@@ -113,3 +116,6 @@ class EnvConfig:
             raise ValueError("minutes_per_turn must be positive")
         if self.slots_small < 0 or self.slots_large < 0:
             raise ValueError("slot counts must be non-negative")
+        if self.supplier_research_minutes <= 0:
+            raise ValueError("supplier_research_minutes must be positive")
+        self.supplier.validate()

--- a/examples/vending_bench/config.py
+++ b/examples/vending_bench/config.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 
 from .state import DemandProfile, Product
+
+DEMAND_PROVIDER_ENV = "DEMAND_PROVIDER"
 
 
 def default_catalogue() -> dict[str, DemandProfile]:
@@ -68,6 +71,10 @@ def default_catalogue() -> dict[str, DemandProfile]:
     return {sku: DemandProfile(product=prod) for sku, prod in products.items()}
 
 
+def _default_demand_provider() -> str:
+    return os.getenv(DEMAND_PROVIDER_ENV, "llm")
+
+
 def generate_new_product_parameters(product_name: str, seed: int) -> tuple[float, float, float, float]:
     """Generate deterministic parameters for a new product based on name and seed.
 
@@ -103,6 +110,7 @@ class EnvConfig:
     max_turns: int = 2000
     minutes_per_turn: int = 60
     catalogue: dict[str, DemandProfile] = field(default_factory=default_catalogue)
+    demand_provider: str = field(default_factory=_default_demand_provider)
 
     def validate(self) -> None:
         if self.starting_cash < 0:
@@ -113,3 +121,5 @@ class EnvConfig:
             raise ValueError("minutes_per_turn must be positive")
         if self.slots_small < 0 or self.slots_large < 0:
             raise ValueError("slot counts must be non-negative")
+        if self.demand_provider.lower() not in {"llm", "deterministic", "rng"}:
+            raise ValueError("demand_provider must be 'llm' or 'deterministic'")

--- a/examples/vending_bench/demand.py
+++ b/examples/vending_bench/demand.py
@@ -1,14 +1,26 @@
-"""Elastic demand model with deterministic randomness."""
+"""Elastic demand model with configurable demand parameter providers."""
 
 from __future__ import annotations
 
 import hashlib
+import json
+import logging
 import math
+import os
 import random
 from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
 
 from .state import DemandProfile, Product, Slot
+
+logger = logging.getLogger(__name__)
+
+
+DEMAND_PROVIDER_ENV = "DEMAND_PROVIDER"
+DEMAND_LLM_MODEL_ENV = "DEMAND_LLM_MODEL"
+DEFAULT_DEMAND_PROVIDER = "llm"
+DEFAULT_DEMAND_LLM_MODEL = "gpt-4o"
 
 
 @dataclass(frozen=True)
@@ -23,30 +35,200 @@ PRICE_FACTOR_MAX = 3.0
 VARIETY_TARGET = 4
 
 
-def generate_parameters(product: Product, *, seed: int | None = None) -> GeneratedDemandParameters:
-    """Deterministically generate demand parameters for a product."""
+def _stable_seed(product: Product, explicit_seed: int | None) -> int:
+    if explicit_seed is not None:
+        return explicit_seed
+    digest = hashlib.sha256(product.sku.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big")
 
-    base_seed: int
-    if seed is not None:
-        base_seed = seed
-    else:
-        # Stable seed using SKU; avoid Python hash randomisation.
-        digest = hashlib.sha256(product.sku.encode("utf-8")).digest()
-        base_seed = int.from_bytes(digest[:8], "big")
 
-    rng = random.Random(base_seed)
+@runtime_checkable
+class DemandParameterProvider(Protocol):
+    def generate(self, product: Product, *, seed: int) -> GeneratedDemandParameters:  # pragma: no cover - protocol
+        ...
 
-    base_price = max(0.05, product.base_price)
-    reference_price = max(0.05, rng.uniform(0.9, 1.1) * base_price)
 
-    base_demand = max(0.25, product.base_daily_demand)
-    base_sales = max(0.25, rng.uniform(0.8, 1.2) * base_demand)
+class DeterministicDemandParameterProvider:
+    """Pure RNG-based provider that mirrors the legacy behaviour."""
 
-    elasticity_hint = product.price_elasticity if product.price_elasticity != 0 else -1.0
-    elasticity_randomiser = rng.uniform(0.85, 1.15)
-    elasticity = elasticity_hint * elasticity_randomiser
-    # Ensure we always return a negative elasticity within sane bounds
-    elasticity = -abs(elasticity)
+    def generate(self, product: Product, *, seed: int) -> GeneratedDemandParameters:
+        rng = random.Random(seed)
+
+        base_price = max(0.05, product.base_price)
+        reference_price = max(0.05, rng.uniform(0.9, 1.1) * base_price)
+
+        base_demand = max(0.25, product.base_daily_demand)
+        base_sales = max(0.25, rng.uniform(0.8, 1.2) * base_demand)
+
+        elasticity_hint = product.price_elasticity if product.price_elasticity != 0 else -1.0
+        elasticity_randomiser = rng.uniform(0.85, 1.15)
+        elasticity = elasticity_hint * elasticity_randomiser
+        elasticity = -abs(elasticity)
+        elasticity = max(-3.0, min(-0.1, elasticity))
+
+        return GeneratedDemandParameters(
+            reference_price=reference_price,
+            base_sales=base_sales,
+            elasticity=elasticity,
+        )
+
+
+class LLMDemandParameterProvider:
+    """LLM-backed demand provider with deterministic fallback."""
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        fallback: DemandParameterProvider | None = None,
+        log_raw: bool = True,
+    ) -> None:
+        self._model = model or os.getenv(DEMAND_LLM_MODEL_ENV, DEFAULT_DEMAND_LLM_MODEL)
+        self._fallback = fallback or DeterministicDemandParameterProvider()
+        self._log_raw = log_raw
+        self._client: Any | None = None
+        self._client_error: Exception | None = None
+
+    def _ensure_client(self) -> Any | None:
+        if self._client is not None or self._client_error is not None:
+            return self._client
+
+        try:
+            from openai import OpenAI  # type: ignore import-not-found
+        except Exception as exc:  # pragma: no cover - exercised via fallback tests
+            self._client_error = exc
+            logger.debug("OpenAI client import failed; using deterministic fallback", exc_info=exc)
+            return None
+
+        try:
+            self._client = OpenAI()
+        except Exception as exc:  # pragma: no cover - exercised via fallback tests
+            self._client_error = exc
+            logger.warning("Failed to initialise OpenAI client; using deterministic fallback", exc_info=exc)
+            return None
+
+        return self._client
+
+    def generate(self, product: Product, *, seed: int) -> GeneratedDemandParameters:
+        client = self._ensure_client()
+        if client is None:
+            return self._fallback.generate(product, seed=seed)
+
+        payload = {
+            "sku": product.sku,
+            "name": product.name,
+            "unit_cost": product.unit_cost,
+            "base_price_hint": product.base_price,
+            "base_daily_demand_hint": product.base_daily_demand,
+            "price_elasticity_hint": product.price_elasticity,
+            "size": product.size,
+            "variety_class": product.variety_class,
+            "slot_capacity": product.slot_capacity,
+            "seed": seed,
+        }
+
+        schema = {
+            "type": "object",
+            "properties": {
+                "reference_price": {"type": "number"},
+                "base_sales": {"type": "number"},
+                "elasticity": {"type": "number"},
+            },
+            "required": ["reference_price", "base_sales", "elasticity"],
+            "additionalProperties": False,
+        }
+
+        try:
+            response = client.responses.create(
+                model=self._model,
+                input=[
+                    {
+                        "role": "system",
+                        "content": "You estimate vending-machine demand parameters. Respond with JSON only.",
+                    },
+                    {
+                        "role": "user",
+                        "content": (
+                            "Given the product profile below, provide reference_price, base_sales, and elasticity "
+                            "for day-zero demand modelling. Use the hints as priors, keep elasticity negative, "
+                            "and respect realistic kiosk pricing."
+                        ),
+                    },
+                    {
+                        "role": "user",
+                        "content": json.dumps(payload, sort_keys=True),
+                    },
+                ],
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "demand_parameters",
+                        "schema": schema,
+                    },
+                },
+                temperature=0.0,
+            )
+        except Exception as exc:  # pragma: no cover - exercised via fallback tests
+            logger.warning("LLM demand provider call failed; using deterministic fallback", exc_info=exc)
+            return self._fallback.generate(product, seed=seed)
+
+        if self._log_raw:
+            try:
+                logger.info(
+                    "LLM demand provider raw response for %s: %s",
+                    product.sku,
+                    json.dumps(response.model_dump(), default=str)
+                    if hasattr(response, "model_dump")
+                    else str(response),
+                )
+            except Exception:  # pragma: no cover - logging best-effort
+                logger.debug("Failed to log LLM raw response", exc_info=True)
+
+        try:
+            data = _extract_response_json(response)
+            return _normalise_parameters(product, data)
+        except Exception as exc:  # pragma: no cover - exercised via fallback tests
+            logger.warning(
+                "LLM demand provider returned invalid payload for %s; falling back", product.sku, exc_info=exc
+            )
+            return self._fallback.generate(product, seed=seed)
+
+
+def _extract_response_json(response: Any) -> dict[str, Any]:
+    if hasattr(response, "output"):
+        for item in getattr(response, "output", []):
+            for part in getattr(item, "content", []):
+                part_type = getattr(part, "type", None)
+                if part_type == "output_json" and hasattr(part, "json_object"):
+                    return dict(part.json_object)
+                if part_type in {"text", "output_text"} and hasattr(part, "text"):
+                    return json.loads(part.text)
+
+    if hasattr(response, "output_text"):
+        return json.loads(response.output_text)
+
+    if hasattr(response, "model_dump"):
+        dumped = response.model_dump()
+        if isinstance(dumped, dict):
+            try:
+                return dict(dumped["output"][0]["content"][0]["json_object"])
+            except Exception as exc:  # pragma: no cover - fallback path
+                raise ValueError("Unable to parse LLM response JSON") from exc
+
+    raise ValueError("LLM response did not contain JSON output")
+
+
+def _normalise_parameters(product: Product, data: dict[str, Any]) -> GeneratedDemandParameters:
+    try:
+        reference_price = float(data["reference_price"])
+        base_sales = float(data["base_sales"])
+        elasticity = float(data["elasticity"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("Invalid demand response fields") from exc
+
+    reference_price = max(0.05, reference_price)
+    base_sales = max(0.25, base_sales)
+    elasticity = -abs(elasticity) if elasticity >= 0 else elasticity
     elasticity = max(-3.0, min(-0.1, elasticity))
 
     return GeneratedDemandParameters(
@@ -54,6 +236,38 @@ def generate_parameters(product: Product, *, seed: int | None = None) -> Generat
         base_sales=base_sales,
         elasticity=elasticity,
     )
+
+
+def create_parameter_provider(name: str | None = None) -> DemandParameterProvider:
+    provider_name = (name or os.getenv(DEMAND_PROVIDER_ENV, DEFAULT_DEMAND_PROVIDER)).strip().lower()
+    if provider_name in {"deterministic", "rng"}:
+        return DeterministicDemandParameterProvider()
+    if provider_name == "llm":
+        return LLMDemandParameterProvider()
+    raise ValueError(f"Unsupported demand provider '{provider_name}'")
+
+
+_DEFAULT_PROVIDER: DemandParameterProvider | None = None
+
+
+def _default_provider() -> DemandParameterProvider:
+    global _DEFAULT_PROVIDER
+    if _DEFAULT_PROVIDER is None:
+        _DEFAULT_PROVIDER = create_parameter_provider()
+    return _DEFAULT_PROVIDER
+
+
+def generate_parameters(
+    product: Product,
+    *,
+    seed: int | None = None,
+    provider: DemandParameterProvider | None = None,
+) -> GeneratedDemandParameters:
+    """Generate demand parameters using the configured provider."""
+
+    provider_obj = provider or _default_provider()
+    resolved_seed = _stable_seed(product, seed)
+    return provider_obj.generate(product, seed=resolved_seed)
 
 
 @dataclass
@@ -70,11 +284,18 @@ class SlotSale:
 
 
 class DemandModel:
-    def __init__(self, seed: int, skus: Iterable[str], profiles: dict[str, DemandProfile] | None = None) -> None:
+    def __init__(
+        self,
+        seed: int,
+        skus: Iterable[str],
+        profiles: dict[str, DemandProfile] | None = None,
+        parameter_provider: DemandParameterProvider | None = None,
+    ) -> None:
         self._seed = seed
         self._sku_index: dict[str, int] = {sku: idx for idx, sku in enumerate(sorted(set(skus)))}
         self._weather_cache: dict[int, float] = {}
         self._noise_cache: dict[tuple[int, str], float] = {}
+        self._parameter_provider = parameter_provider or _default_provider()
         if profiles:
             self.ensure_profiles(profiles)
 
@@ -102,7 +323,11 @@ class DemandModel:
         if reference_price is not None and base_sales is not None and elasticity is not None:
             return reference_price, base_sales, elasticity
 
-        params = generate_parameters(profile.product, seed=self._parameter_seed(sku))
+        params = generate_parameters(
+            profile.product,
+            seed=self._parameter_seed(sku),
+            provider=self._parameter_provider,
+        )
         profile.reference_price = params.reference_price
         profile.base_daily_sales = params.base_sales
         profile.price_elasticity = params.elasticity

--- a/examples/vending_bench/design.md
+++ b/examples/vending_bench/design.md
@@ -45,7 +45,7 @@
 - Use `ai_web_search` to discover products and contacts, generate quotes with deterministic LLM calls, and attach replies to email inbox/outbox.【F:examples/vending_bench/source_excerpts.md-L10-L13】
 
 ### Demand Model
-- Generate reference prices, elasticity, and base sales at order time; compute demand via elasticity adjustments, seasonal/weather multipliers, variety penalties, and capped noisy draws.【F:examples/vending_bench/source_excerpts.md-L17-L19】
+- Generate reference prices, elasticity, and base sales via a GPT-4o-backed provider (JSON schema) with deterministic fallback when API access is unavailable; compute demand via elasticity adjustments, seasonal/weather multipliers, variety penalties, and capped noisy draws.【F:examples/vending_bench/source_excerpts.md-L17-L19】
 
 ### Financial Management
 - Track machine cash versus liquid balance, deduct daily fees, enforce buffers, and trigger price or ordering adjustments when thresholds fall below heuristics.【F:examples/vending_bench/source_excerpts.md-L15-L16】【F:examples/vending_bench/source_excerpts.md-L26-L26】

--- a/examples/vending_bench/env.py
+++ b/examples/vending_bench/env.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 
 from .config import EnvConfig, generate_new_product_parameters
-from .demand import DemandModel
+from .demand import DemandModel, create_parameter_provider
 from .metrics import compute_net_worth, cumulative_units_sold, daily_report
 from .state import (
     LARGE_ITEM_ROWS,
@@ -53,10 +53,12 @@ class VendingEnv:
         )
         self.state.reset_daily_counters()
         self._rng = random.Random(self.config.seed)
+        demand_provider = create_parameter_provider(self.config.demand_provider)
         self._demand = DemandModel(
             self.config.seed + 1,
             self.state.demand_profiles.keys(),
             profiles=self.state.demand_profiles,
+            parameter_provider=demand_provider,
         )
         self._supplier = SupplierModel(self.config.seed + 2, self.state.demand_profiles)
         self._morning_initialised = False

--- a/examples/vending_bench/env.py
+++ b/examples/vending_bench/env.py
@@ -27,7 +27,7 @@ from .state import (
     clone_machine_inventory,
     serialize_machine_inventory,
 )
-from .supplier import SupplierEmailResponse, SupplierModel
+from .supplier import SupplierContact, SupplierEmailResponse, SupplierModel
 
 
 @dataclass
@@ -58,7 +58,7 @@ class VendingEnv:
             self.state.demand_profiles.keys(),
             profiles=self.state.demand_profiles,
         )
-        self._supplier = SupplierModel(self.config.seed + 2, self.state.demand_profiles)
+        self._supplier = SupplierModel(self.config.seed + 2, self.state.demand_profiles, config=self.config.supplier)
         self._morning_initialised = False
 
     @staticmethod
@@ -137,9 +137,31 @@ class VendingEnv:
         # Ensure the supplier model knows about this new product
         self._supplier._products[sku] = product
         # Rebuild supplier contacts to include the new product
-        self._supplier._contacts = self._supplier._build_contacts()
+        self._supplier.refresh_stub_directory()
 
         return profile
+
+    def register_supplier_contacts(self, contacts: Iterable[SupplierContact]) -> None:
+        """Register supplier contacts discovered via external search."""
+
+        self._supplier.register_external_contacts(contacts)
+        directory = self.state.telemetry.setdefault("supplier_contacts", {})
+        for contact in contacts:
+            catalog_summary = {
+                sku: {
+                    "min_order": offer.min_order_quantity,
+                    "wholesale_price": offer.wholesale_price,
+                    "lead_time_days": offer.lead_time_days,
+                }
+                for sku, offer in contact.products.items()
+            }
+            directory[contact.email] = {
+                "name": contact.name,
+                "source": contact.source,
+                "website": contact.website,
+                "phone": contact.phone,
+                "catalog": catalog_summary,
+            }
 
     def advance_time(self, minutes: int | None = None) -> None:
         if minutes is None:

--- a/examples/vending_bench/integrations.py
+++ b/examples/vending_bench/integrations.py
@@ -1,0 +1,359 @@
+"""External service integrations for Vending-Bench suppliers."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Sequence
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+class PerplexityIntegrationError(RuntimeError):
+    """Raised when the Perplexity integration cannot return usable search results."""
+
+
+@dataclass(slots=True)
+class SupplierSearchItem:
+    """Structured item entry returned from supplier search."""
+
+    sku: str
+    min_order: int | None = None
+    wholesale_price: float | None = None
+    lead_time_days: tuple[int, int] | None = None
+    notes: str | None = None
+
+
+@dataclass(slots=True)
+class SupplierSearchHit:
+    """Supplier metadata produced by Perplexity search or deterministic stub."""
+
+    name: str
+    email: str
+    catalog: list[SupplierSearchItem]
+    website: str | None = None
+    phone: str | None = None
+    tags: tuple[str, ...] = ()
+    notes: str | None = None
+    source: str = "stub"
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def has_known_skus(self, known_skus: Sequence[str]) -> bool:
+        """Return True if the hit references at least one known SKU."""
+
+        valid = {sku.lower() for sku in known_skus}
+        for item in self.catalog:
+            if item.sku.lower() in valid:
+                return True
+        return False
+
+
+class PerplexityClient:
+    """Minimal client for Perplexity's chat completions API with structured output."""
+
+    _ENDPOINT_DEFAULT = "https://api.perplexity.ai/chat/completions"
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str | None = None,
+        timeout: float = 30.0,
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key must be provided")
+        self._api_key = api_key
+        self._model = model or os.getenv("PERPLEXITY_MODEL", "sonar-pro")
+        self._timeout = timeout
+        self._endpoint = os.getenv("PERPLEXITY_API_URL", self._ENDPOINT_DEFAULT)
+
+    def search_suppliers(self, *, query: str, limit: int, known_skus: Sequence[str]) -> list[SupplierSearchHit]:
+        if not query:
+            raise ValueError("query must be non-empty")
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+
+        schema = self._build_json_schema()
+        payload = {
+            "model": self._model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a procurement analyst compiling vending machine suppliers. "
+                        "Return ONLY JSON that adheres to the provided schema."
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": (
+                        "Research real wholesalers that can service vending machines. "
+                        "Use the query verbatim, prefer North American suppliers, and map their catalog to the allowed SKUs. "
+                        "Allowed SKUs: "
+                        + ", ".join(sorted({sku.lower() for sku in known_skus}))
+                        + f". Limit results to {limit}."
+                    ),
+                },
+            ],
+            "response_format": {"type": "json_schema", "json_schema": schema},
+            "max_output_tokens": 800,
+            "temperature": 0.2,
+        }
+
+        headers = {
+            "Authorization": f"Bearer {self._api_key}",
+            "Content-Type": "application/json",
+        }
+
+        response = requests.post(
+            self._endpoint,
+            json=payload,
+            headers=headers,
+            timeout=self._timeout,
+        )
+        if response.status_code >= 400:
+            raise PerplexityIntegrationError(
+                f"Perplexity API returned {response.status_code}: {response.text[:200]}"
+            )
+
+        try:
+            body = response.json()
+        except json.JSONDecodeError as exc:  # pragma: no cover - response contract violation
+            raise PerplexityIntegrationError("Perplexity response was not valid JSON") from exc
+
+        content = self._extract_content(body)
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise PerplexityIntegrationError("Perplexity did not return JSON matching the schema") from exc
+
+        suppliers = parsed.get("suppliers", [])
+        hits: list[SupplierSearchHit] = []
+        for entry in suppliers[:limit]:
+            try:
+                hits.append(self._convert_entry(entry))
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logger.debug("Skipping malformed supplier entry: %s", exc)
+                continue
+
+        return hits
+
+    @staticmethod
+    def _extract_content(body: dict[str, Any]) -> str:
+        choices = body.get("choices")
+        if not choices:
+            raise PerplexityIntegrationError("Perplexity response missing choices")
+        message = choices[0].get("message", {})
+        content = message.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            text_parts = [part.get("text", "") for part in content if isinstance(part, dict)]
+            combined = "".join(text_parts).strip()
+            if combined:
+                return combined
+        raise PerplexityIntegrationError("Perplexity message content missing text payload")
+
+    @staticmethod
+    def _convert_entry(entry: dict[str, Any]) -> SupplierSearchHit:
+        catalog_data = entry.get("catalog") or []
+        items: list[SupplierSearchItem] = []
+        for item in catalog_data:
+            sku = str(item.get("sku", "")).strip()
+            if not sku:
+                continue
+            lead = item.get("lead_time_days")
+            lead_tuple: tuple[int, int] | None = None
+            if isinstance(lead, list) and lead:
+                if len(lead) == 1:
+                    lead_tuple = (int(lead[0]), int(lead[0]))
+                elif len(lead) >= 2:
+                    lead_tuple = (int(lead[0]), int(lead[1]))
+            items.append(
+                SupplierSearchItem(
+                    sku=sku,
+                    min_order=_coerce_int(item.get("min_order")),
+                    wholesale_price=_coerce_float(item.get("wholesale_price")),
+                    lead_time_days=lead_tuple,
+                    notes=item.get("notes"),
+                )
+            )
+
+        tags = entry.get("tags") or []
+        return SupplierSearchHit(
+            name=entry.get("name", "").strip(),
+            email=entry.get("email", "").strip().lower(),
+            website=_sanitize_url(entry.get("website")),
+            phone=_sanitize_phone(entry.get("phone")),
+            catalog=items,
+            tags=tuple(tag.lower() for tag in tags if isinstance(tag, str)),
+            notes=entry.get("summary"),
+            source=entry.get("source", "perplexity"),
+            raw=entry,
+        )
+
+    @staticmethod
+    def _build_json_schema() -> dict[str, Any]:
+        return {
+            "name": "supplier_search_results",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "suppliers": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["name", "email", "catalog"],
+                            "properties": {
+                                "name": {"type": "string"},
+                                "email": {"type": "string"},
+                                "website": {"type": "string"},
+                                "phone": {"type": "string"},
+                                "summary": {"type": "string"},
+                                "tags": {
+                                    "type": "array",
+                                    "items": {"type": "string"},
+                                },
+                                "source": {"type": "string"},
+                                "catalog": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "required": ["sku"],
+                                        "properties": {
+                                            "sku": {"type": "string"},
+                                            "min_order": {"type": ["integer", "null"]},
+                                            "wholesale_price": {"type": ["number", "null"]},
+                                            "lead_time_days": {
+                                                "type": "array",
+                                                "items": {"type": "integer"},
+                                                "minItems": 1,
+                                                "maxItems": 2,
+                                            },
+                                            "notes": {"type": "string"},
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    }
+                },
+                "required": ["suppliers"],
+            },
+        }
+
+
+def deterministic_supplier_hits(
+    *, env: Any, limit: int, source: str = "stub"
+) -> list[SupplierSearchHit]:
+    """Return deterministic supplier hits aligned with the current catalogue."""
+
+    catalogue = env.state.demand_profiles
+    hits: list[SupplierSearchHit] = []
+
+    def build_items(skus: Iterable[str], *, multiplier: float, min_order: int, lead: tuple[int, int]) -> list[SupplierSearchItem]:
+        items: list[SupplierSearchItem] = []
+        for sku in skus:
+            profile = catalogue.get(sku)
+            if profile is None:
+                continue
+            wholesale = round(profile.product.unit_cost * multiplier, 2)
+            items.append(
+                SupplierSearchItem(
+                    sku=sku,
+                    min_order=min_order,
+                    wholesale_price=wholesale,
+                    lead_time_days=lead,
+                )
+            )
+        return items
+
+    hits.append(
+        SupplierSearchHit(
+            name="Regional Food Distributors Inc.",
+            email="orders@rfd-inc.com",
+            website="https://example-supplier1.com",
+            phone="+1-800-555-0110",
+            catalog=build_items(
+                ("coke", "water", "energy_drink"),
+                multiplier=0.95,
+                min_order=24,
+                lead=(2, 5),
+            ),
+            tags=("beverage", "snack"),
+            notes="Bulk beverage catalogue with predictable 2-5 day delivery windows across the Midwest.",
+            source=source,
+        )
+    )
+    hits.append(
+        SupplierSearchHit(
+            name="QuickStock Vending Solutions",
+            email="supply@quickstock.com",
+            website="https://example-supplier2.com",
+            phone="+1-800-555-0148",
+            catalog=build_items(
+                ("chips", "chocolate_bar", "energy_drink"),
+                multiplier=0.9,
+                min_order=12,
+                lead=(2, 4),
+            ),
+            tags=("snack", "impulse"),
+            notes="Fast-turn snack distributor with local cross-dock for 2-4 day replenishment.",
+            source=source,
+        )
+    )
+    hits.append(
+        SupplierSearchHit(
+            name="Metro Wholesale Foods",
+            email="sales@metrofoods.example",
+            website="https://example-supplier3.com",
+            phone="+1-800-555-0190",
+            catalog=build_items(
+                catalogue.keys(),
+                multiplier=1.0,
+                min_order=18,
+                lead=(3, 6),
+            ),
+            tags=("balanced", "office"),
+            notes="Balanced assortment for office routes with 3-6 day scheduled deliveries.",
+            source=source,
+        )
+    )
+
+    return hits[:limit]
+
+
+def _coerce_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _sanitize_url(value: Any) -> str | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _sanitize_phone(value: Any) -> str | None:
+    if not value:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/examples/vending_bench/state.py
+++ b/examples/vending_bench/state.py
@@ -73,12 +73,16 @@ class SupplierProductOffer:
 
 @dataclass
 class SupplierContact:
-    """Supplier directory entry used for deterministic email responses."""
+    """Supplier directory entry used for email responses and GPT grounding."""
 
     name: str
     email: str
     categories: tuple[str, ...]
     products: dict[str, SupplierProductOffer]
+    phone: str | None = None
+    website: str | None = None
+    source: str = "stub"
+    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass

--- a/examples/vending_bench/supplier.py
+++ b/examples/vending_bench/supplier.py
@@ -1,12 +1,14 @@
-"""Deterministic supplier fixtures and email responders for the vending simulator."""
+"""Supplier email responders and integrations for the vending simulator."""
 
 from __future__ import annotations
 
+import logging
+import os
 import random
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .state import (
     EmailMessage,
@@ -17,14 +19,18 @@ from .state import (
     SupplierProductOffer,
 )
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover - import-time guard only
     from .state import DemandProfile
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
 class SupplierConfig:
-    min_lead_time_days: int = 1
-    max_lead_time_days: int = 4
+    """Configuration controlling supplier lead times and behaviour."""
+
+    min_lead_time_days: int = 2
+    max_lead_time_days: int = 5
 
     def validate(self) -> None:
         if self.min_lead_time_days < 0:
@@ -57,19 +63,40 @@ class SupplierModel:
         self.config = config or SupplierConfig()
         self.config.validate()
 
-        # Copy base product data for deterministic offers
         self._products: dict[str, Product] = {sku: profile.product for sku, profile in catalogue.items()}
-        self._contacts = self._build_contacts()
+        self._stub_contacts = self._build_contacts()
+        self._dynamic_contacts: dict[str, SupplierContact] = {}
+        self._contacts: dict[str, SupplierContact] = dict(self._stub_contacts)
+        self._directory_mode: str = "stub"
+
+        self._gpt_api_key = os.getenv("OPENAI_API_KEY")
+        self._force_stub = os.getenv("VENDING_SUPPLIER_FORCE_STUB", "").strip().lower() in {"1", "true", "yes"}
+        self._gpt_model = os.getenv("VENDING_SUPPLIER_GPT_MODEL", "gpt-4o-mini")
+        self._gpt_client: Any | None = None
 
     def supplier_directory(self) -> dict[str, SupplierContact]:
         """Expose the supplier directory for inspection/testing."""
 
-        return self._contacts.copy()
+        return dict(self._contacts)
+
+    def register_external_contacts(self, contacts: Iterable[SupplierContact]) -> None:
+        """Register live supplier contacts sourced from Perplexity search."""
+
+        for contact in contacts:
+            email = contact.email.lower()
+            contact.email = email
+            source = contact.source or contact.metadata.get("source", "perplexity")
+            contact.source = source
+            contact.metadata.setdefault("source", source)
+            self._dynamic_contacts[email] = contact
+            self._contacts[email] = contact
+            if source != "stub":
+                self._directory_mode = "live"
 
     def process_email(self, state: SimulatorState, message: EmailMessage) -> SupplierEmailResponse:
         """Return a reply and optional order(s) in response to an outbound email."""
 
-        contact = self._contacts.get(message.recipient.lower())
+        contact = self._lookup_contact(message.recipient)
         if contact is None:
             return SupplierEmailResponse(reply=None, orders=[])
 
@@ -85,14 +112,19 @@ class SupplierModel:
             if not requested:
                 return SupplierEmailResponse(
                     reply=self._clarification_response(
-                        contact, message, "Please specify quantities for each SKU you'd like to order.", state.day
+                        contact,
+                        message,
+                        "Please specify quantities for each SKU you'd like to order.",
+                        state.day,
                     ),
                     orders=[],
                 )
 
             missing_requirements: list[str] = []
             for sku, qty in requested.items():
-                offer = contact.products[sku]
+                offer = contact.products.get(sku)
+                if offer is None:
+                    continue
                 if qty < offer.min_order_quantity:
                     missing_requirements.append(
                         f"{offer.product.name} (SKU {sku}) requires a minimum order of {offer.min_order_quantity} units"
@@ -131,7 +163,18 @@ class SupplierModel:
                     orders=[],
                 )
 
-            offers = [contact.products[sku] for sku in requested.keys()]
+            offers = [contact.products[sku] for sku in requested.keys() if sku in contact.products]
+            if not offers:
+                return SupplierEmailResponse(
+                    reply=self._clarification_response(
+                        contact,
+                        message,
+                        "We could not match the requested SKUs to our catalog. Please reference items from the quote.",
+                        state.day,
+                    ),
+                    orders=[],
+                )
+
             total_cost = sum(requested[offer.product.sku] * offer.wholesale_price for offer in offers)
             if state.cash_balance < total_cost:
                 return SupplierEmailResponse(
@@ -151,7 +194,6 @@ class SupplierModel:
             reply = self._order_confirmation(contact, message, orders, state.day)
             return SupplierEmailResponse(reply=reply, orders=orders)
 
-        # Default response asking for clarification when the intent is unclear
         return SupplierEmailResponse(
             reply=self._clarification_response(
                 contact,
@@ -175,6 +217,14 @@ class SupplierModel:
         return delivered, pending
 
     # Internal helpers -----------------------------------------------------------------
+
+    def _lookup_contact(self, email: str) -> SupplierContact | None:
+        key = email.lower()
+        if key in self._dynamic_contacts:
+            return self._dynamic_contacts[key]
+        if self._directory_mode == "stub":
+            return self._stub_contacts.get(key)
+        return None
 
     def _build_contacts(self) -> dict[str, SupplierContact]:
         """Construct deterministic supplier directory."""
@@ -200,6 +250,7 @@ class SupplierModel:
                 keywords=tuple(sorted(keywords)),
             )
 
+        baseline_lead = self._baseline_lead()
         contacts = [
             SupplierContact(
                 name="Regional Food Distributors Inc.",
@@ -210,10 +261,16 @@ class SupplierModel:
                         sku,
                         wholesale_price=self._products[sku].unit_cost * 0.95,
                         min_order=24 if sku != "energy_drink" else 12,
-                        lead=(2, 5),
+                        lead=baseline_lead,
                     )
                     for sku in ("coke", "water", "energy_drink")
                     if sku in self._products
+                },
+                phone="+1-800-555-0110",
+                website="https://example-supplier1.com",
+                source="stub",
+                metadata={
+                    "notes": "Bulk beverage catalogue with predictable delivery windows.",
                 },
             ),
             SupplierContact(
@@ -225,10 +282,16 @@ class SupplierModel:
                         sku,
                         wholesale_price=self._products[sku].unit_cost * 0.9,
                         min_order=12,
-                        lead=(1, 3),
+                        lead=baseline_lead,
                     )
                     for sku in ("chips", "chocolate_bar", "energy_drink")
                     if sku in self._products
+                },
+                phone="+1-800-555-0148",
+                website="https://example-supplier2.com",
+                source="stub",
+                metadata={
+                    "notes": "Fast-turn snack distributor with local cross-dock facilities.",
                 },
             ),
             SupplierContact(
@@ -240,15 +303,32 @@ class SupplierModel:
                         sku,
                         wholesale_price=self._products[sku].unit_cost,
                         min_order=18,
-                        lead=(3, 6),
+                        lead=baseline_lead,
                         extra_keywords=(self._products[sku].variety_class.lower(),),
                     )
                     for sku in self._products.keys()
+                },
+                phone="+1-800-555-0190",
+                website="https://example-supplier3.com",
+                source="stub",
+                metadata={
+                    "notes": "Balanced assortment for office routes with scheduled deliveries.",
                 },
             ),
         ]
 
         return {contact.email.lower(): contact for contact in contacts if contact.products}
+
+    def refresh_stub_directory(self) -> None:
+        """Rebuild deterministic contacts when the catalogue changes."""
+
+        self._stub_contacts = self._build_contacts()
+        if self._directory_mode == "stub":
+            self._contacts = dict(self._stub_contacts)
+        else:
+            merged = dict(self._stub_contacts)
+            merged.update(self._dynamic_contacts)
+            self._contacts = merged
 
     def _is_quote_request(self, subject: str, body: str) -> bool:
         return any(keyword in subject or keyword in body for keyword in self.QUOTE_KEYWORDS)
@@ -278,6 +358,12 @@ class SupplierModel:
         return "deliver" in lower_body and "to" in lower_body
 
     def _quote_response(self, contact: SupplierContact, message: EmailMessage, current_day: int) -> EmailMessage:
+        subject = f"Re: {message.subject or 'Supplier inquiry'}"
+        if self._gpt_enabled():
+            generated = self._quote_response_gpt(contact, message, subject, current_day)
+            if generated is not None:
+                return generated
+
         lines = [
             f"Hello, this is {contact.name}.",
             "Here are our current wholesale options:",
@@ -294,10 +380,62 @@ class SupplierModel:
         body = "\n".join(lines)
         return EmailMessage(
             day=current_day + 1,
-            subject=f"Re: {message.subject or 'Supplier inquiry'}",
+            subject=subject,
             body=body,
             sender=contact.email,
             recipient=message.sender,
+        )
+
+    def _quote_response_gpt(
+        self,
+        contact: SupplierContact,
+        message: EmailMessage,
+        subject: str,
+        current_day: int,
+    ) -> EmailMessage | None:
+        client = self._ensure_gpt_client()
+        if client is None:
+            return None
+
+        catalog_lines = []
+        for offer in sorted(contact.products.values(), key=lambda o: o.product.name):
+            lead_min, lead_max = offer.lead_time_days
+            catalog_lines.append(
+                "SKU {sku}: {name}, price ${price:.2f}, MOQ {moq}, lead {lead_min}-{lead_max} days".format(
+                    sku=offer.product.sku,
+                    name=offer.product.name,
+                    price=offer.wholesale_price,
+                    moq=offer.min_order_quantity,
+                    lead_min=lead_min,
+                    lead_max=lead_max,
+                )
+            )
+
+        metadata_notes = contact.metadata.get("notes") if contact.metadata else None
+        system_prompt = (
+            f"You are {contact.name}'s account manager."
+            " Write a concise, professional email responding to a vending operator's quote request."
+            " Include pricing, minimum order quantities, and delivery lead times for each SKU."
+            " Do not invent SKUs beyond those provided."
+        )
+        user_prompt = (
+            f"Customer message (day {current_day}):\n{message.body}\n\n"
+            f"Supplier details:\nWebsite: {contact.website or 'N/A'}\n"
+            f"Phone: {contact.phone or 'N/A'}\n"
+            f"Notes: {metadata_notes or 'n/a'}\n"
+            "Catalog entries:\n"
+            + "\n".join(catalog_lines)
+            + "\nRespond with a short greeting, bullet list of the catalog terms, and a closing line."
+        )
+
+        return self._generate_gpt_email(
+            client=client,
+            subject=subject,
+            sender=contact.email,
+            recipient=message.sender,
+            current_day=current_day,
+            body_prompt=user_prompt,
+            system_prompt=system_prompt,
         )
 
     def _clarification_response(
@@ -327,6 +465,12 @@ class SupplierModel:
         orders: list[Order],
         current_day: int,
     ) -> EmailMessage:
+        subject = f"Order confirmation #{message.day}-{current_day + 1}"
+        if self._gpt_enabled():
+            generated = self._order_confirmation_gpt(contact, message, orders, subject, current_day)
+            if generated is not None:
+                return generated
+
         lines = [
             "Thanks for your purchase order. We've scheduled the following items:",
         ]
@@ -341,10 +485,90 @@ class SupplierModel:
         body = "\n".join(lines)
         return EmailMessage(
             day=current_day + 1,
-            subject=f"Order confirmation #{message.day}-{current_day + 1}",
+            subject=subject,
             body=body,
             sender=contact.email,
             recipient=message.sender,
+        )
+
+    def _order_confirmation_gpt(
+        self,
+        contact: SupplierContact,
+        message: EmailMessage,
+        orders: list[Order],
+        subject: str,
+        current_day: int,
+    ) -> EmailMessage | None:
+        client = self._ensure_gpt_client()
+        if client is None:
+            return None
+
+        order_lines = [
+            (
+                f"SKU {order.sku}: {self._products[order.sku].name}, quantity {order.quantity}, "
+                f"unit ${order.unit_cost:.2f}, delivery day {order.delivery_day}"
+            )
+            for order in orders
+        ]
+        total_cost = sum(order.total_cost for order in orders)
+        system_prompt = (
+            f"You are {contact.name}'s order manager."
+            " Confirm the received purchase order, restate each line item, and summarise cost and delivery day."
+            " Mention that payment has been applied to the buyer's account."
+        )
+        user_prompt = (
+            f"Customer message (day {current_day}):\n{message.body}\n\n"
+            "Line items:\n"
+            + "\n".join(order_lines)
+            + f"\nTotal cost: ${total_cost:.2f}.\n"
+            "Acknowledge receipt, confirm delivery schedule, and invite follow-up if changes are needed."
+        )
+
+        return self._generate_gpt_email(
+            client=client,
+            subject=subject,
+            sender=contact.email,
+            recipient=message.sender,
+            current_day=current_day,
+            body_prompt=user_prompt,
+            system_prompt=system_prompt,
+        )
+
+    def _generate_gpt_email(
+        self,
+        *,
+        client: Any,
+        subject: str,
+        sender: str,
+        recipient: str,
+        current_day: int,
+        body_prompt: str,
+        system_prompt: str,
+    ) -> EmailMessage | None:
+        try:
+            response = client.responses.create(
+                model=self._gpt_model,
+                input=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": body_prompt},
+                ],
+                max_output_tokens=500,
+                temperature=0.4,
+            )
+        except Exception as exc:  # pragma: no cover - network errors
+            logger.warning("GPT supplier reply failed: %s", exc)
+            return None
+
+        body = getattr(response, "output_text", "").strip()
+        if not body:
+            return None
+
+        return EmailMessage(
+            day=current_day + 1,
+            subject=subject,
+            body=body,
+            sender=sender,
+            recipient=recipient,
         )
 
     def _create_order(self, offer: SupplierProductOffer, quantity: int, day_ordered: int) -> Order:
@@ -359,4 +583,22 @@ class SupplierModel:
             unit_cost=offer.wholesale_price,
             day_ordered=day_ordered,
             delivery_day=delivery_day,
+        )
+
+    def _ensure_gpt_client(self) -> Any | None:
+        if not self._gpt_enabled():
+            return None
+        if self._gpt_client is None:
+            from openai import OpenAI
+
+            self._gpt_client = OpenAI()
+        return self._gpt_client
+
+    def _gpt_enabled(self) -> bool:
+        return bool(self._gpt_api_key) and not self._force_stub
+
+    def _baseline_lead(self) -> tuple[int, int]:
+        return (
+            max(1, self.config.min_lead_time_days),
+            max(self.config.min_lead_time_days, self.config.max_lead_time_days),
         )

--- a/examples/vending_bench/tools.py
+++ b/examples/vending_bench/tools.py
@@ -8,14 +8,29 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
 from inspect_agents.exceptions import ToolException
 
+from .integrations import (
+    PerplexityClient,
+    PerplexityIntegrationError,
+    SupplierSearchHit,
+    SupplierSearchItem,
+    deterministic_supplier_hits,
+)
 from .runtime import get_env, increment_tool_count
-from .state import MINUTES_PER_DAY, EmailMessage, aggregate_sku_quantities, serialize_machine_inventory
+from .state import (
+    MINUTES_PER_DAY,
+    EmailMessage,
+    SupplierContact,
+    SupplierProductOffer,
+    aggregate_sku_quantities,
+    serialize_machine_inventory,
+)
 
 if TYPE_CHECKING:
     from inspect_ai.tool._tool import Tool
@@ -226,6 +241,88 @@ def _inventory_snapshot(location: str) -> tuple[dict[str, int], int]:
     total_units = sum(inventory.values())
 
     return inventory, total_units
+
+
+def _should_force_stub_mode() -> bool:
+    """Return True if integrations should operate in deterministic stub mode."""
+
+    return os.getenv("VENDING_SUPPLIER_FORCE_STUB", "").strip().lower() in {"1", "true", "yes"}
+
+
+def _default_lead_range(env: Any) -> tuple[int, int]:
+    cfg = getattr(env.config, "supplier", None)
+    if cfg is None:
+        return (2, 5)
+    return (max(1, cfg.min_lead_time_days), max(cfg.min_lead_time_days, cfg.max_lead_time_days))
+
+
+def _build_offer_from_item(
+    env: Any,
+    item: SupplierSearchItem,
+    default_lead: tuple[int, int],
+) -> SupplierProductOffer | None:
+    sku = item.sku.lower()
+    profile = env.state.demand_profiles.get(sku)
+    if profile is None:
+        return None
+
+    min_order = item.min_order if item.min_order and item.min_order > 0 else max(6, profile.product.slot_capacity)
+    wholesale = item.wholesale_price if item.wholesale_price and item.wholesale_price > 0 else profile.product.unit_cost
+    lead = item.lead_time_days or default_lead
+
+    keywords = {
+        profile.product.sku.lower(),
+        profile.product.name.lower(),
+        profile.product.name.lower().replace(" ", ""),
+    }
+
+    return SupplierProductOffer(
+        product=profile.product,
+        wholesale_price=wholesale,
+        min_order_quantity=min_order,
+        lead_time_days=lead,
+        keywords=tuple(sorted(keywords)),
+    )
+
+
+def _hit_to_contact(env: Any, hit: SupplierSearchHit, default_lead: tuple[int, int]) -> SupplierContact | None:
+    offers: dict[str, SupplierProductOffer] = {}
+    for item in hit.catalog:
+        offer = _build_offer_from_item(env, item, default_lead)
+        if offer is not None:
+            offers[offer.product.sku] = offer
+
+    if not offers:
+        return None
+
+    metadata = {"notes": hit.notes, "raw": hit.raw}
+    return SupplierContact(
+        name=hit.name,
+        email=hit.email.lower(),
+        categories=hit.tags,
+        products=offers,
+        phone=hit.phone,
+        website=hit.website,
+        source=hit.source,
+        metadata=metadata,
+    )
+
+
+def _format_catalog_output(contact: SupplierContact) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for offer in contact.products.values():
+        lead_min, lead_max = offer.lead_time_days
+        lead_text = f"{lead_min}-{lead_max}" if lead_min != lead_max else str(lead_min)
+        entries.append(
+            {
+                "sku": offer.product.sku,
+                "name": offer.product.name,
+                "min_order": offer.min_order_quantity,
+                "wholesale_price": round(offer.wholesale_price, 2),
+                "lead_time_days": lead_text,
+            }
+        )
+    return entries
 
 
 def _log_tool_event(
@@ -881,17 +978,17 @@ def wait_for_next_day() -> Tool:
 
 
 def ai_web_search() -> Tool:
-    """Perform web search for supplier information (deterministic stub)."""
+    """Perform web search for supplier information via Perplexity with stub fallback."""
 
     from inspect_ai.tool._tool import tool
 
     @tool(name="ai_web_search")
     def ai_web_search_impl(query: str, max_results: int = 5) -> WebSearchResult:
-        """Search for supplier contacts and product information (deterministic results).
+        """Search for supplier contacts and product information.
 
         Args:
             query: Search query string
-            max_results: Maximum number of search results to return
+            max_results: Maximum number of search results to return (1-20)
         """
 
         if max_results < 1 or max_results > 20:
@@ -901,104 +998,79 @@ def ai_web_search() -> Tool:
 
         try:
             env = get_env()
-            env.advance_time(60)  # 1 hour for research
+            available_skus = list(env.state.demand_profiles.keys())
+            default_lead = _default_lead_range(env)
 
-            # Enhanced deterministic supplier search results with dynamic content based on catalog
-            stub_results: list[dict[str, Any]] = []
-            normalized_query = query.lower()
+            paired: list[tuple[SupplierSearchHit, SupplierContact]] = []
+            mode = "stub"
 
-            # Get available SKUs from environment catalog
-            available_skus = set(env.state.demand_profiles.keys())
-
-            if any(term in normalized_query for term in ("supplier", "vendor", "wholesale", "contact")):
-                # Build dynamic supplier results based on available catalog
-                suppliers_data = [
-                    {
-                        "name": "Regional Food Distributors Inc.",
-                        "email": "orders@rfd-inc.com",
-                        "phone": "+1-800-555-0110",
-                        "url": "https://example-supplier1.com",
-                        "snippet": "Bulk beverage catalogue with predictable 2-5 day delivery windows across the Midwest.",
-                        "categories": ["beverage"],
-                        "specialties": ["coke", "water", "energy_drink"],
-                        "min_orders": {"coke": 24, "water": 24, "energy_drink": 12},
-                        "price_multiplier": 0.95,
-                        "lead_time": "2-5",
-                    },
-                    {
-                        "name": "QuickStock Vending Solutions",
-                        "email": "supply@quickstock.com",
-                        "phone": "+1-800-555-0148",
-                        "url": "https://example-supplier2.com",
-                        "snippet": "Fast-turn snack distributor with local cross-dock for 1-3 day replenishment.",
-                        "categories": ["snack", "impulse"],
-                        "specialties": ["chips", "chocolate_bar", "energy_drink"],
-                        "min_orders": {"chips": 12, "chocolate_bar": 12, "energy_drink": 12},
-                        "price_multiplier": 0.90,
-                        "lead_time": "1-3",
-                    },
-                    {
-                        "name": "Metro Wholesale Foods",
-                        "email": "sales@metrofoods.example",
-                        "phone": "+1-800-555-0190",
-                        "url": "https://example-supplier3.com",
-                        "snippet": "Balanced assortment for office routes with 3-6 day scheduled deliveries.",
-                        "categories": ["balanced", "office"],
-                        "specialties": list(available_skus),
-                        "min_orders": {sku: 18 for sku in available_skus},
-                        "price_multiplier": 1.0,
-                        "lead_time": "3-6",
-                    },
-                ]
-
-                for supplier in suppliers_data:
-                    # Build catalog for available SKUs
-                    catalog = []
-                    for sku in supplier["specialties"]:
-                        if sku in available_skus:
-                            profile = env.state.demand_profiles[sku]
-                            wholesale_price = profile.product.unit_cost * supplier["price_multiplier"]
-                            catalog.append(
-                                {
-                                    "sku": sku,
-                                    "name": profile.product.name,
-                                    "category": "beverage"
-                                    if "beverage" in supplier["categories"]
-                                    else profile.product.variety_class.lower(),
-                                    "min_order": supplier["min_orders"].get(sku, 18),
-                                    "wholesale_price": round(wholesale_price, 2),
-                                    "lead_time_days": supplier["lead_time"],
-                                }
-                            )
-
-                    if catalog:  # Only include suppliers with available products
-                        stub_results.append(
-                            {
-                                "title": supplier["name"],
-                                "url": supplier["url"],
-                                "snippet": supplier["snippet"],
-                                "contact": {"email": supplier["email"], "phone": supplier["phone"]},
-                                "categories": supplier["categories"],
-                                "catalog": catalog,
-                            }
+            if not _should_force_stub_mode():
+                api_key = os.getenv("PERPLEXITY_API_KEY")
+                if api_key:
+                    try:
+                        client = PerplexityClient(api_key=api_key)
+                        live_hits = client.search_suppliers(query=query, limit=max_results, known_skus=available_skus)
+                        for hit in live_hits:
+                            if not hit.has_known_skus(available_skus):
+                                continue
+                            contact = _hit_to_contact(env, hit, default_lead)
+                            if contact is not None:
+                                paired.append((hit, contact))
+                        if paired:
+                            mode = "live"
+                    except PerplexityIntegrationError as exc:
+                        logging.getLogger(__name__).warning(
+                            "Perplexity search failed (%s); falling back to stub results", exc
                         )
-            elif any(term in normalized_query for term in ("product list", "snack", "catalogue", "pricing")):
-                stub_results = [
-                    {
-                        "title": "Top vending machine performers",
-                        "url": "https://example-market-research.com",
-                        "snippet": "Chilled beverages and grab-and-go snacks drive 68% of office vending revenue.",
-                        "data": {
-                            "beverage": {"top_skus": ["coke", "water", "energy_drink"], "avg_wholesale": 0.60},
-                            "snack": {"top_skus": ["chips", "chocolate_bar"], "avg_wholesale": 0.62},
-                        },
-                    }
-                ]
+                    except Exception as exc:  # pragma: no cover - network failures
+                        logging.getLogger(__name__).warning(
+                            "Unexpected Perplexity error (%s); using deterministic stub", exc
+                        )
 
-            result = WebSearchResult(query=query, results=stub_results[:max_results])
+            if not paired:
+                stub_hits = deterministic_supplier_hits(env=env, limit=max_results)
+                for hit in stub_hits:
+                    contact = _hit_to_contact(env, hit, default_lead)
+                    if contact is not None:
+                        paired.append((hit, contact))
+                mode = "stub"
+
+            contacts = [contact for _, contact in paired]
+            if contacts:
+                env.register_supplier_contacts(contacts)
+
+            env.advance_time(env.config.supplier_research_minutes)
+
+            results_payload: list[dict[str, Any]] = []
+            for hit, contact in paired[:max_results]:
+                results_payload.append(
+                    {
+                        "title": contact.name,
+                        "url": contact.website,
+                        "snippet": hit.notes,
+                        "contact": {"email": contact.email, "phone": contact.phone},
+                        "categories": list(contact.categories),
+                        "catalog": _format_catalog_output(contact),
+                        "source": contact.source,
+                    }
+                )
+
+            env.state.telemetry.setdefault("supplier_search_history", []).append(
+                {
+                    "query": query,
+                    "mode": mode,
+                    "results": [contact.email for contact in contacts],
+                    "day": env.state.day,
+                }
+            )
+
+            result = WebSearchResult(query=query, results=results_payload[:max_results])
 
             _log_tool_event(
-                name="ai_web_search", phase="end", extra={"query": query, "results_count": len(result.results)}, t0=t0
+                name="ai_web_search",
+                phase="end",
+                extra={"query": query, "results_count": len(result.results), "mode": mode},
+                t0=t0,
             )
 
             return result

--- a/tests/integration/vending_bench/test_supplier_loop.py
+++ b/tests/integration/vending_bench/test_supplier_loop.py
@@ -1,0 +1,127 @@
+"""Integration tests for supplier search and email workflows."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from examples.vending_bench.integrations import SupplierSearchHit, SupplierSearchItem
+from examples.vending_bench.tools import ai_web_search
+from examples.vending_bench.env import VendingEnv
+from examples.vending_bench.supplier import SupplierModel
+from examples.vending_bench.state import EmailMessage
+
+
+@pytest.fixture
+def vending_env(monkeypatch: pytest.MonkeyPatch) -> VendingEnv:
+    env = VendingEnv()
+    monkeypatch.setattr("examples.vending_bench.tools.get_env", lambda: env)
+    return env
+
+
+def test_live_quote_flow_with_mocked_integrations(monkeypatch: pytest.MonkeyPatch, vending_env: VendingEnv) -> None:
+    """Perplexity + GPT integration should register suppliers and generate grounded quotes."""
+
+    monkeypatch.setenv("PERPLEXITY_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "test-openai")
+    monkeypatch.delenv("VENDING_SUPPLIER_FORCE_STUB", raising=False)
+    vending_env._supplier._gpt_api_key = "test-openai"
+    vending_env._supplier._force_stub = False
+
+    hit = SupplierSearchHit(
+        name="Delta Wholesale",
+        email="sales@delta-wholesale.test",
+        catalog=[
+            SupplierSearchItem(sku="coke", min_order=30, wholesale_price=0.62, lead_time_days=(2, 4)),
+            SupplierSearchItem(sku="water", min_order=40, wholesale_price=0.28, lead_time_days=(2, 4)),
+        ],
+        website="https://delta-wholesale.test",
+        phone="+1-555-0100",
+        tags=("beverage",),
+        notes="Regional beverage wholesaler with two-day delivery.",
+        source="perplexity",
+    )
+
+    with patch("examples.vending_bench.tools.PerplexityClient.search_suppliers", return_value=[hit]):
+        generated_bodies: list[str] = []
+
+        def fake_generate(
+            self: SupplierModel,
+            *,
+            client: object,
+            subject: str,
+            sender: str,
+            recipient: str,
+            current_day: int,
+            body_prompt: str,
+            system_prompt: str,
+        ) -> EmailMessage:
+            generated_bodies.append(body_prompt)
+            return EmailMessage(
+                day=current_day + 1,
+                subject=subject,
+                body="Live GPT reply",
+                sender=sender,
+                recipient=recipient,
+            )
+
+        monkeypatch.setattr(SupplierModel, "_ensure_gpt_client", lambda self: object())
+        monkeypatch.setattr(SupplierModel, "_generate_gpt_email", fake_generate)
+
+        search_tool = ai_web_search()
+        result = search_tool(query="vending machine suppliers", max_results=3)
+
+    assert result.results, "Expected at least one supplier result"
+    first = result.results[0]
+    assert first["contact"]["email"] == "sales@delta-wholesale.test"
+    assert first["catalog"][0]["sku"] == "coke"
+
+    history = vending_env.state.telemetry.get("supplier_search_history", [])
+    assert history, "Search history should be recorded"
+    assert history[-1]["mode"] == "live"
+
+    # Send a quote request and ensure GPT integration handled it
+    vending_env.queue_email(
+        recipient="sales@delta-wholesale.test",
+        subject="Quote request",
+        body="Hi Supplier, please share pricing for Coke and water.",
+    )
+
+    assert generated_bodies, "GPT generator should have been invoked for quote replies"
+    scheduled = vending_env.state.scheduled_inbox
+    assert scheduled, "Supplier reply should be scheduled for next morning"
+    assert scheduled[0].message.body == "Live GPT reply"
+
+
+def test_purchase_flow_requires_account_and_confirms_orders(vending_env: VendingEnv) -> None:
+    """Purchase orders must include account/address and yield delayed deliveries."""
+
+    # Missing account number triggers clarification
+    response = vending_env.queue_email(
+        recipient="orders@rfd-inc.com",
+        subject="Purchase order",
+        body="Ordering 48 units of Coke for next week delivery.",
+    )
+    assert response.day == vending_env.state.day
+    assert vending_env.state.scheduled_inbox[-1].message.body.startswith("Hello, this is Regional Food")
+    assert "account number" in vending_env.state.scheduled_inbox[-1].message.body.lower()
+
+    # Provide complete information to receive confirmation and scheduled delivery
+    vending_env.queue_email(
+        recipient="orders@rfd-inc.com",
+        subject="Purchase order",
+        body=(
+            "Please process 48 units of Coke.\n"
+            "Account number 123-456.\n"
+            "Deliver to 123 Main St, Springfield."
+        ),
+    )
+
+    assert vending_env.state.outstanding_orders, "Order should be recorded as outstanding"
+    order = vending_env.state.outstanding_orders[-1]
+    assert 2 <= order.delivery_day <= 5, "Delivery should be scheduled with 2-5 day lead"
+
+    confirmation = vending_env.state.scheduled_inbox[-1].message
+    assert "Thanks for your purchase order" in confirmation.body
+    assert str(order.delivery_day) in confirmation.body

--- a/tests/unit/vending_bench/test_demand.py
+++ b/tests/unit/vending_bench/test_demand.py
@@ -4,8 +4,17 @@ from __future__ import annotations
 
 import pytest
 
+from examples.vending_bench import demand as demand_module
 from examples.vending_bench.demand import DemandModel, generate_parameters
 from examples.vending_bench.state import DemandProfile, Product, Slot
+
+
+@pytest.fixture(autouse=True)
+def _force_deterministic_provider(monkeypatch):
+    """Ensure legacy deterministic provider for demand-model tests."""
+
+    monkeypatch.setenv("DEMAND_PROVIDER", "deterministic")
+    monkeypatch.setattr(demand_module, "_DEFAULT_PROVIDER", None, raising=False)
 
 
 def _build_product(*, sku: str = "test_sku") -> Product:

--- a/tests/unit/vending_bench/test_demand_parameters.py
+++ b/tests/unit/vending_bench/test_demand_parameters.py
@@ -1,0 +1,96 @@
+"""Tests for demand parameter provider plumbing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from examples.vending_bench import demand as demand_module
+from examples.vending_bench.demand import (
+    DemandModel,
+    GeneratedDemandParameters,
+    create_parameter_provider,
+    generate_parameters,
+)
+from examples.vending_bench.state import DemandProfile, Product, Slot
+
+
+@dataclass
+class _StubProvider:
+    reference_price: float
+    base_sales: float
+    elasticity: float
+    calls: list[tuple[str, int]] = field(default_factory=list)
+
+    def generate(self, product: Product, *, seed: int) -> GeneratedDemandParameters:
+        self.calls.append((product.sku, seed))
+        return GeneratedDemandParameters(
+            reference_price=self.reference_price,
+            base_sales=self.base_sales,
+            elasticity=self.elasticity,
+        )
+
+
+def _build_product(*, sku: str = "sku") -> Product:
+    return Product(
+        sku=sku,
+        name="Test",
+        size="small",
+        slot_capacity=12,
+        unit_cost=1.0,
+        base_price=2.0,
+        base_daily_demand=10.0,
+        price_elasticity=-1.0,
+        variety_class="snack",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_provider_cache(monkeypatch):
+    monkeypatch.setattr(demand_module, "_DEFAULT_PROVIDER", None, raising=False)
+
+
+def test_generate_parameters_uses_explicit_provider():
+    product = _build_product()
+    provider = _StubProvider(reference_price=3.0, base_sales=7.0, elasticity=-1.2)
+
+    params = generate_parameters(product, seed=42, provider=provider)
+
+    assert params.reference_price == pytest.approx(3.0)
+    assert params.base_sales == pytest.approx(7.0)
+    assert params.elasticity == pytest.approx(-1.2)
+    assert provider.calls == [(product.sku, 42)]
+
+
+def test_demand_model_caches_provider_results_across_days():
+    product = _build_product(sku="cache")
+    profile = DemandProfile(product=product)
+    provider = _StubProvider(reference_price=2.5, base_sales=9.0, elasticity=-1.1)
+
+    model = DemandModel(
+        seed=11,
+        skus=[product.sku],
+        profiles={product.sku: profile},
+        parameter_provider=provider,
+    )
+
+    assert len(provider.calls) == 1
+    call_sku, _ = provider.calls[0]
+    assert call_sku == product.sku
+
+    machine = [[Slot(sku=product.sku, quantity=10, price=2.5, capacity=product.slot_capacity)]]
+
+    model.simulate_day(day=0, demand_profiles={product.sku: profile}, machine_inventory=machine)
+    model.simulate_day(day=1, demand_profiles={product.sku: profile}, machine_inventory=machine)
+
+    assert len(provider.calls) == 1
+    assert profile.reference_price == pytest.approx(2.5)
+    assert profile.base_daily_sales == pytest.approx(9.0)
+    assert profile.price_elasticity == pytest.approx(-1.1)
+
+
+def test_create_parameter_provider_honours_env(monkeypatch):
+    monkeypatch.setenv("DEMAND_PROVIDER", "deterministic")
+    provider = create_parameter_provider()
+    assert isinstance(provider, demand_module.DeterministicDemandParameterProvider)


### PR DESCRIPTION
## What & Why

  Implement GPT-4o backed demand parameter generation with deterministic fallback to align Vending-Bench with the benchmark spec and expose configuration for selecting providers. Document the new behaviour and add
  tests to guard caching and env overrides.

  Scope

  - Provider abstraction, EnvConfig wiring, and VendingEnv integration
  - Provider-focused unit tests and deterministic fixture guard
  - Documentation across README, design doc, and environment reference

  ## Changes

  - Introduced LLMDemandParameterProvider, deterministic fallback, provider factory, and EnvConfig integration
  - Updated VendingEnv to instantiate providers per configuration and cache SKU parameters immediately
  - Added unit tests for provider caching, env overrides, and deterministic fixtures; forced RNG path in legacy tests
  - Documented demand provider configuration, env vars, and design intent

  Affected areas

  - examples/vending_bench/demand.py
  - examples/vending_bench/config.py
  - examples/vending_bench/env.py
  - tests/unit/vending_bench/
  - docs/reference/environment.md
  - examples/vending_bench/README.md
  - examples/vending_bench/design.md

  ## Risk & Rollback

  Risk checklist

  - [ ] Breaking change (compat plan described)
  - [ ] Data migration/backfill (plan + window)
  - [ ] Security/privacy change (perms/secrets/PII)
  - [ ] Performance impact (baseline vs. new)
  - [ ] Observability updated (metrics/logs/alerts)
  - [ ] Feature flag (name, rollout, kill-switch tested)

  Rollback
  Revert commits cf78f4d, b4cf756, and a16e6cb. No data changes; reverting restores RNG-only behaviour.

  ## Test Plan

  Automated

  - Unit: CI=1 NO_NETWORK=1 PYTHONPATH=src UV_CACHE_DIR=.uv-cache uv run --no_workspace pytest -q tests/unit/vending_bench/test_demand_parameters.py tests/unit/vending_bench/test_demand.py
  - Integration/E2E: not run (Inspect-AI vendored tree absent)

  Manual / Evidence

  - Steps + expected signals: N/A
  - UI: N/A
  - Performance: N/A

  ## Follow-ups (optional)

  - Restore vendored external/inspect_ai to re-enable approval/kill-switch integration suites.