### PR TITLE
Add embedding-backed vending memory cache with checkpoints

### DIFF
--- a/examples/vending_bench/README.md
+++ b/examples/vending_bench/README.md
@@ -71,6 +71,17 @@ uv run pytest -q tests/unit/vending_bench -k mirror_sync
 - **Vector Database**: Email embeddings and searchable history
 - **Context Management**: Periodic summarization to maintain working memory budget
 
+### Embedding Configuration
+- **Default Provider**: The vector store issues OpenAI `text-embedding-3-small` requests. Set `OPENAI_API_KEY` in your environment before running the benchmark.
+- **Model Overrides**: Optional env vars `VENDING_BENCH_EMBEDDING_MODEL` and `VENDING_BENCH_EMBEDDING_DIM` change the embedding model or target dimensionality.
+- **Offline/CI Fallback**: Set `VENDING_BENCH_EMBEDDINGS=deterministic` to use a deterministic hash-based embedding for local testing without network access. This fallback is not intended for benchmark scoring.
+- **Global Cache**: The embedding layer uses a content-addressed cache keyed by `(provider, model, dimensions, text hash)`. Control it via `VENDING_BENCH_EMBED_CACHE={rw|ro|off}` and `VENDING_BENCH_EMBED_CACHE_PATH` (defaults to `$XDG_CACHE_HOME/inspect_agents/`). Cache hits reduce latency and cost without persisting cross-run memory.
+
+### Memory Checkpoints
+- **Per-Run Snapshots**: Provide `--run-id <id>` when invoking `examples.vending_bench.run` to enable automatic checkpointing under `.inspect/vending_checkpoints/` (override with `--memory-checkpoint-dir`).
+- **Resume Support**: Pass `--resume-run` alongside the run id to resume the exact memory state for that episode. New runs without `--resume-run` always start from an empty store.
+- **Isolation Guarantee**: Checkpoints are scoped by run id; a fresh run never preloads memory from previous episodes, but does reuse cached embeddings for faster recompute.
+
 ## Configuration
 
 Key configuration options in `examples/vending_bench/config.py`:

--- a/examples/vending_bench/memory.py
+++ b/examples/vending_bench/memory.py
@@ -7,10 +7,18 @@ in the design requirements.
 
 from __future__ import annotations
 
+import base64
+import hashlib
 import json
 import logging
+import math
+import os
+import pickle
+import sqlite3
 import time
-from typing import TYPE_CHECKING, Any
+import unicodedata
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 from pydantic import BaseModel, Field
 
@@ -62,6 +70,7 @@ class VectorEntry(BaseModel):
     content: str
     metadata: dict[str, Any]
     timestamp: float
+    embedding: list[float] = Field(default_factory=list)
     similarity: float = 0.0
 
 
@@ -73,14 +82,28 @@ class VectorResult(BaseModel):
     query: str = ""
 
 
+@runtime_checkable
+class EmbeddingProvider(Protocol):
+    """Protocol describing embedding providers used by the vector memory."""
+
+    def embed(self, text: str) -> list[float]:
+        """Return a numeric embedding for the provided text."""
+
+
 class MemoryStore:
     """In-memory storage for all memory operations."""
 
-    def __init__(self):
+    def __init__(
+        self, embedding_provider: EmbeddingProvider | None = None, embedding_cache: EmbeddingCache | None = None
+    ):
         self.scratchpad: list[ScratchpadEntry] = []
         self.key_value: dict[str, dict[str, Any]] = {}  # key -> {value, timestamp, ttl_days}
         self.vector_store: list[VectorEntry] = []
         self._next_id = 1
+        self.embedding_provider: EmbeddingProvider = embedding_provider or _build_embedding_provider()
+        self.embedding_cache: EmbeddingCache | None = embedding_cache or _build_embedding_cache()
+        self._checkpoint_path: Path | None = None
+        self._auto_checkpoint = False
 
     def _generate_id(self) -> str:
         """Generate unique ID."""
@@ -102,18 +125,346 @@ class MemoryStore:
         for key in expired_keys:
             del self.key_value[key]
 
-    def _simple_similarity(self, text1: str, text2: str) -> float:
-        """Simple similarity calculation based on word overlap."""
-        words1 = set(text1.lower().split())
-        words2 = set(text2.lower().split())
+    def embed_text(self, text: str) -> list[float]:
+        """Compute a normalised embedding for text using the configured provider."""
+        cache_key: str | None = None
+        text_hash = ""
 
-        if not words1 or not words2:
+        if self.embedding_cache is not None:
+            cache_key, text_hash = _make_cache_key(text, self.embedding_provider)
+            cached = self.embedding_cache.get(cache_key)
+            if cached is not None:
+                return _normalise_vector(cached)
+
+        embedding = self.embedding_provider.embed(text)
+        normalised = _normalise_vector(embedding)
+
+        if self.embedding_cache is not None and cache_key is not None:
+            self.embedding_cache.set(cache_key, normalised, text_hash=text_hash)
+
+        return normalised
+
+    def cosine_similarity(self, a: list[float], b: list[float]) -> float:
+        """Compute cosine similarity between two vectors, guarding zero norms."""
+        if not a or not b:
             return 0.0
 
-        intersection = len(words1.intersection(words2))
-        union = len(words1.union(words2))
+        if len(a) != len(b):
+            min_len = min(len(a), len(b))
+            a = a[:min_len]
+            b = b[:min_len]
 
-        return intersection / union if union > 0 else 0.0
+        dot_product = sum(x * y for x, y in zip(a, b))
+        norm_a = math.sqrt(sum(x * x for x in a))
+        norm_b = math.sqrt(sum(y * y for y in b))
+
+        if norm_a == 0.0 or norm_b == 0.0:
+            return 0.0
+
+        return dot_product / (norm_a * norm_b)
+
+    def ensure_entry_embedding(self, entry: VectorEntry) -> list[float]:
+        """Ensure the vector entry has an embedding, generating one if absent."""
+        if not entry.embedding:
+            entry.embedding = self.embed_text(entry.content)
+        return entry.embedding
+
+    def configure_checkpoint(self, *, directory: Path, run_id: str, auto_persist: bool = False) -> None:
+        checkpoint_dir = directory.expanduser()
+        checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        self._checkpoint_path = checkpoint_dir / f"{run_id}-memory.json"
+        self._auto_checkpoint = auto_persist
+        if auto_persist:
+            self.persist_checkpoint()
+
+    def persist_checkpoint(self) -> None:
+        if self._checkpoint_path is None:
+            return
+
+        payload = self._checkpoint_payload()
+        temp_path = self._checkpoint_path.with_suffix(self._checkpoint_path.suffix + ".tmp")
+        with temp_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False)
+        temp_path.replace(self._checkpoint_path)
+
+    def maybe_persist_checkpoint(self) -> None:
+        if self._auto_checkpoint:
+            self.persist_checkpoint()
+
+    def _checkpoint_payload(self) -> dict[str, Any]:
+        state = {
+            "scratchpad": self.scratchpad,
+            "key_value": self.key_value,
+            "vector_store": self.vector_store,
+            "_next_id": self._next_id,
+        }
+        encoded = base64.b64encode(pickle.dumps(state)).decode("ascii")
+        return {"version": 1, "payload": encoded}
+
+    @classmethod
+    def load_checkpoint(
+        cls,
+        *,
+        directory: Path,
+        run_id: str,
+        embedding_provider: EmbeddingProvider | None = None,
+        embedding_cache: EmbeddingCache | None = None,
+    ) -> MemoryStore | None:
+        checkpoint_dir = directory.expanduser()
+        path = checkpoint_dir / f"{run_id}-memory.json"
+        if not path.exists():
+            return None
+
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+
+        if data.get("version") != 1 or "payload" not in data:
+            raise ValueError("Unsupported memory checkpoint format")
+
+        state = pickle.loads(base64.b64decode(data["payload"]))
+
+        store = cls(embedding_provider=embedding_provider, embedding_cache=embedding_cache)
+        store.scratchpad = state.get("scratchpad", [])
+        store.key_value = state.get("key_value", {})
+        store.vector_store = state.get("vector_store", [])
+        store._next_id = state.get("_next_id", 1)
+        store.configure_checkpoint(directory=checkpoint_dir, run_id=run_id, auto_persist=False)
+        return store
+
+
+_EMBEDDING_PROVIDER_ENV = "VENDING_BENCH_EMBEDDINGS"
+_EMBEDDING_MODEL_ENV = "VENDING_BENCH_EMBEDDING_MODEL"
+_EMBEDDING_DIM_ENV = "VENDING_BENCH_EMBEDDING_DIM"
+_EMBED_CACHE_MODE_ENV = "VENDING_BENCH_EMBED_CACHE"
+_EMBED_CACHE_PATH_ENV = "VENDING_BENCH_EMBED_CACHE_PATH"
+_DEFAULT_CACHE_FILENAME = "vending_bench_embeddings.sqlite"
+_CHECKPOINT_DIR_ENV = "VENDING_BENCH_MEMORY_CHECKPOINT_DIR"
+_RUN_ID_ENV = "VENDING_BENCH_MEMORY_RUN_ID"
+_RESUME_ENV = "VENDING_BENCH_MEMORY_RESUME"
+_FALLBACK_WARNING_EMITTED = False
+
+
+def _normalise_vector(values: list[float]) -> list[float]:
+    """Return a unit-length copy of the provided vector (or zeros if empty)."""
+    if not values:
+        return []
+
+    norm = math.sqrt(sum(v * v for v in values))
+    if norm == 0.0:
+        return [0.0 for _ in values]
+
+    return [v / norm for v in values]
+
+
+def _default_cache_path() -> Path:
+    cache_root = os.environ.get("XDG_CACHE_HOME")
+    if cache_root:
+        base = Path(cache_root)
+    else:
+        base = Path.home() / ".cache"
+    return base / "inspect_agents" / _DEFAULT_CACHE_FILENAME
+
+
+class EmbeddingCache:
+    """Simple SQLite-backed cache for embedding vectors."""
+
+    def __init__(self, *, path: Path, mode: Literal["off", "ro", "rw"] = "rw") -> None:
+        self.mode = mode
+        self.enabled = mode != "off"
+        self.read_only = mode == "ro"
+        self._conn: sqlite3.Connection | None = None
+        if not self.enabled:
+            return
+
+        db_path = path.expanduser()
+
+        if self.read_only:
+            if not db_path.exists():
+                self.enabled = False
+                return
+            self._conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, check_same_thread=False)
+        else:
+            db_path.parent.mkdir(parents=True, exist_ok=True)
+            self._conn = sqlite3.connect(db_path, check_same_thread=False)
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS embeddings (
+                    cache_key TEXT PRIMARY KEY,
+                    embedding TEXT NOT NULL,
+                    dimensions INTEGER NOT NULL,
+                    text_hash TEXT NOT NULL,
+                    created_at REAL NOT NULL
+                )
+                """
+            )
+            self._conn.commit()
+
+    def get(self, cache_key: str) -> list[float] | None:
+        if not self.enabled or self._conn is None:
+            return None
+
+        cursor = self._conn.execute("SELECT embedding FROM embeddings WHERE cache_key = ?", (cache_key,))
+        row = cursor.fetchone()
+        if row is None:
+            return None
+
+        try:
+            return [float(x) for x in json.loads(row[0])]
+        except json.JSONDecodeError:
+            return None
+
+    def set(self, cache_key: str, embedding: list[float], *, text_hash: str) -> None:
+        if not self.enabled or self.read_only or self._conn is None:
+            return
+
+        payload = json.dumps(embedding)
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO embeddings (cache_key, embedding, dimensions, text_hash, created_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (cache_key, payload, len(embedding), text_hash, time.time()),
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+
+class OpenAIEmbeddingProvider:
+    """Embedding provider backed by the OpenAI embeddings API."""
+
+    def __init__(self, model: str = "text-embedding-3-small", *, dimensions: int | None = None):
+        from openai import OpenAI
+
+        self._client = OpenAI()
+        self._model = model
+        self._dimensions = dimensions
+
+    def embed(self, text: str) -> list[float]:
+        response = self._client.embeddings.create(
+            model=self._model,
+            input=[text],
+            dimensions=self._dimensions,
+        )
+        return list(response.data[0].embedding)
+
+    @property
+    def cache_id(self) -> str:
+        dims = self._dimensions if self._dimensions is not None else "default"
+        return f"openai:{self._model}:{dims}"
+
+
+class DeterministicEmbeddingProvider:
+    """Deterministic embedding provider for offline or CI runs."""
+
+    def __init__(self, *, dimensions: int = 256):
+        if dimensions <= 0:
+            raise ValueError("dimensions must be a positive integer")
+        self._dimensions = dimensions
+
+    def embed(self, text: str) -> list[float]:
+        if not text:
+            return [0.0] * self._dimensions
+
+        vector = [0.0] * self._dimensions
+        tokens = text.lower().split()
+        if not tokens:
+            tokens = [text.lower()]
+
+        for token in tokens:
+            digest = hashlib.sha256(token.encode("utf-8")).digest()
+            for index in range(self._dimensions):
+                byte_value = digest[index % len(digest)]
+                vector[index] += (byte_value / 255.0) * 2.0 - 1.0
+
+        return vector
+
+    @property
+    def cache_id(self) -> str:
+        return f"deterministic:{self._dimensions}"
+
+
+def _cache_identity_for_provider(provider: EmbeddingProvider) -> str:
+    cache_id = getattr(provider, "cache_id", None)
+    if cache_id:
+        return str(cache_id)
+    return f"{provider.__class__.__module__}.{provider.__class__.__qualname__}"
+
+
+def _normalise_text_for_cache(text: str) -> str:
+    normalised = unicodedata.normalize("NFC", text)
+    return " ".join(normalised.split()).strip()
+
+
+def _build_embedding_provider() -> EmbeddingProvider:
+    """Instantiate the embedding provider based on environment configuration."""
+
+    provider_choice = os.environ.get(_EMBEDDING_PROVIDER_ENV, "openai").strip().lower()
+    configured_dimensions = _get_int_env(_EMBEDDING_DIM_ENV)
+
+    if provider_choice in {"deterministic", "fallback"}:
+        return DeterministicEmbeddingProvider(dimensions=configured_dimensions or 256)
+
+    if provider_choice in {"openai", "default"}:
+        api_key = os.environ.get("OPENAI_API_KEY")
+        model = os.environ.get(_EMBEDDING_MODEL_ENV, "text-embedding-3-small")
+
+        if not api_key:
+            return _fallback_with_warning(
+                "OPENAI_API_KEY is not set; using deterministic embeddings", configured_dimensions
+            )
+
+        return OpenAIEmbeddingProvider(model=model, dimensions=configured_dimensions)
+
+    raise ValueError(f"Unsupported embedding provider '{provider_choice}' for vending bench vector memory")
+
+
+def _build_embedding_cache() -> EmbeddingCache | None:
+    mode = os.environ.get(_EMBED_CACHE_MODE_ENV, "rw").strip().lower()
+    if mode not in {"rw", "ro", "off"}:
+        logging.getLogger(__name__).warning("Unknown embedding cache mode '%s'; defaulting to 'rw'", mode)
+        mode = "rw"
+
+    path_value = os.environ.get(_EMBED_CACHE_PATH_ENV)
+    cache_path = Path(path_value).expanduser() if path_value else _default_cache_path()
+
+    cache = EmbeddingCache(path=cache_path, mode=mode)
+    return cache if cache.enabled else None
+
+
+def _fallback_with_warning(reason: str, dimensions: int | None) -> EmbeddingProvider:
+    """Log a single warning about the deterministic fallback and return the provider."""
+
+    global _FALLBACK_WARNING_EMITTED
+    if not _FALLBACK_WARNING_EMITTED:
+        logging.getLogger(__name__).warning("%s", reason)
+        _FALLBACK_WARNING_EMITTED = True
+
+    return DeterministicEmbeddingProvider(dimensions=dimensions or 256)
+
+
+def _get_int_env(name: str) -> int | None:
+    value = os.environ.get(name)
+    if value is None or not value.strip():
+        return None
+    try:
+        parsed = int(value)
+    except ValueError as exc:  # pragma: no cover - defensive logging for invalid config
+        logging.getLogger(__name__).warning("Invalid integer value for %s: %s", name, value)
+        raise ValueError(f"Environment variable {name} must be an integer") from exc
+    if parsed <= 0:
+        raise ValueError(f"Environment variable {name} must be positive")
+    return parsed
+
+
+def _make_cache_key(text: str, provider: EmbeddingProvider) -> tuple[str, str]:
+    normalised = _normalise_text_for_cache(text)
+    digest = hashlib.sha256(normalised.encode("utf-8")).hexdigest()
+    identity = _cache_identity_for_provider(provider)
+    return f"{identity}:{digest}", digest
 
 
 def _log_memory_event(
@@ -193,6 +544,8 @@ def scratchpad_append() -> Tool:
             memory_store.scratchpad.append(entry)
 
             result = ScratchpadResult(entries=[entry], total_count=len(memory_store.scratchpad), operation="append")
+
+            memory_store.maybe_persist_checkpoint()
 
             _log_memory_event(
                 name="scratchpad_append",
@@ -387,6 +740,8 @@ def scratchpad_summarise() -> Tool:
                             vector_entry.metadata["summarised"] = True
                             vector_flagged += 1
 
+            summary_embedding = memory_store.embed_text(summary_text)
+
             vector_summary_entry = VectorEntry(
                 id=memory_store._generate_id(),
                 content=summary_text,
@@ -398,6 +753,7 @@ def scratchpad_summarise() -> Tool:
                     "source_char_count": total_source_chars,
                 },
                 timestamp=time.time(),
+                embedding=summary_embedding,
             )
             memory_store.vector_store.append(vector_summary_entry)
 
@@ -406,6 +762,8 @@ def scratchpad_summarise() -> Tool:
                 total_count=len(memory_store.scratchpad),
                 operation="summarise",
             )
+
+            memory_store.maybe_persist_checkpoint()
 
             _log_memory_event(
                 name="scratchpad_summarise",
@@ -463,6 +821,8 @@ def kv_set() -> Tool:
             memory_store.key_value[key] = {"value": value, "timestamp": time.time(), "ttl_days": ttl_days}
 
             result = KeyValueResult(key=key, value=value, found=True, operation="set")
+
+            memory_store.maybe_persist_checkpoint()
 
             _log_memory_event(
                 name="kv_set", phase="end", extra={"key": key, "total_keys": len(memory_store.key_value)}, t0=t0
@@ -579,13 +939,21 @@ def vector_store() -> Tool:
         try:
             memory_store = get_memory_store()
 
+            embedding = memory_store.embed_text(content)
+
             entry = VectorEntry(
-                id=memory_store._generate_id(), content=content, metadata=metadata, timestamp=time.time()
+                id=memory_store._generate_id(),
+                content=content,
+                metadata=metadata,
+                timestamp=time.time(),
+                embedding=embedding,
             )
 
             memory_store.vector_store.append(entry)
 
             result = VectorResult(entries=[entry], operation="store")
+
+            memory_store.maybe_persist_checkpoint()
 
             _log_memory_event(
                 name="vector_store",
@@ -630,12 +998,15 @@ def vector_search() -> Tool:
         try:
             memory_store = get_memory_store()
 
+            query_embedding = memory_store.embed_text(query)
+
             # Calculate similarities and filter
             scored_entries = []
             for entry in memory_store.vector_store:
-                similarity = memory_store._simple_similarity(query, entry.content)
+                entry_embedding = memory_store.ensure_entry_embedding(entry)
+                similarity = memory_store.cosine_similarity(query_embedding, entry_embedding)
                 if similarity >= similarity_threshold:
-                    entry_copy = VectorEntry(**entry.dict())
+                    entry_copy = entry.model_copy(deep=True)
                     entry_copy.similarity = similarity
                     scored_entries.append(entry_copy)
 

--- a/examples/vending_bench/run.py
+++ b/examples/vending_bench/run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -18,7 +19,13 @@ from inspect_agents.run import run_agent
 from .. import _utils
 from .config import EnvConfig
 from .env import VendingEnv
-from .memory import MemoryStore, memory_tools
+from .memory import (
+    _CHECKPOINT_DIR_ENV,
+    _RESUME_ENV,
+    _RUN_ID_ENV,
+    MemoryStore,
+    memory_tools,
+)
 from .metrics import collect_episode_metrics
 from .prompts import PHYSICAL_AGENT_PROMPT, SUPERVISOR_PROMPT
 from .runtime import clear_runtime_context, set_runtime_context
@@ -101,10 +108,29 @@ def _summarise_state(state: Any) -> dict[str, Any]:
     return summary
 
 
-def run_episode(seed: int, model: str, *, include_defaults: bool = False) -> dict[str, Any]:
+def _initialise_memory_store(*, run_id: str | None, checkpoint_dir: Path | None, resume: bool) -> MemoryStore:
+    if run_id and checkpoint_dir:
+        directory = checkpoint_dir.expanduser()
+        store = MemoryStore.load_checkpoint(directory=directory, run_id=run_id) if resume else None
+        if store is None:
+            store = MemoryStore()
+        store.configure_checkpoint(directory=directory, run_id=run_id, auto_persist=True)
+        return store
+    return MemoryStore()
+
+
+def run_episode(
+    seed: int,
+    model: str,
+    *,
+    include_defaults: bool = False,
+    run_id: str | None = None,
+    checkpoint_dir: Path | None = None,
+    resume: bool = False,
+) -> dict[str, Any]:
     config = EnvConfig(seed=seed)
     env = VendingEnv(config)
-    memory = MemoryStore()
+    memory = _initialise_memory_store(run_id=run_id, checkpoint_dir=checkpoint_dir, resume=resume)
 
     set_runtime_context(env=env, memory=memory)
     try:
@@ -135,14 +161,47 @@ def main() -> None:
     parser.add_argument(
         "--include-default-tools", action="store_true", help="Inject inspect_agents default tool preset"
     )
+    parser.add_argument("--run-id", type=str, help="Identifier used for memory checkpointing")
+    parser.add_argument(
+        "--resume-run", action="store_true", help="Resume the memory checkpoint for the provided run id"
+    )
+    parser.add_argument(
+        "--memory-checkpoint-dir",
+        type=Path,
+        default=Path(".inspect/vending_checkpoints"),
+        help="Directory used to store per-run memory checkpoints",
+    )
     args = parser.parse_args()
 
     _utils.apply_tool_env_from_args(args)
     _utils.ensure_repo_src_on_path()
     _utils.load_env_files(Path(__file__).parent, include_template=True)
 
+    run_id = args.run_id
+    checkpoint_dir = args.memory_checkpoint_dir if run_id else None
+    resume_run = bool(args.resume_run and run_id)
+
+    if run_id:
+        os.environ[_RUN_ID_ENV] = run_id
+        os.environ[_CHECKPOINT_DIR_ENV] = str(args.memory_checkpoint_dir)
+        if resume_run:
+            os.environ[_RESUME_ENV] = "1"
+        else:
+            os.environ.pop(_RESUME_ENV, None)
+    else:
+        os.environ.pop(_RUN_ID_ENV, None)
+        os.environ.pop(_CHECKPOINT_DIR_ENV, None)
+        os.environ.pop(_RESUME_ENV, None)
+
     model_id = resolve_model(provider=args.provider, model=args.model)
-    metrics = run_episode(seed=args.seed, model=model_id, include_defaults=args.include_default_tools)
+    metrics = run_episode(
+        seed=args.seed,
+        model=model_id,
+        include_defaults=args.include_default_tools,
+        run_id=run_id,
+        checkpoint_dir=checkpoint_dir,
+        resume=resume_run,
+    )
 
     output = json.dumps(metrics, indent=2)
     if args.output:

--- a/examples/vending_bench/runtime.py
+++ b/examples/vending_bench/runtime.py
@@ -7,8 +7,10 @@ share mutable state without relying on Inspect's StoreModel wiring.
 
 from __future__ import annotations
 
+import os
 from collections import Counter
 from contextvars import ContextVar
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - import-time guard only
@@ -70,8 +72,26 @@ def get_memory_store() -> MemoryStore:
 
     memory = _MEMORY_CTX.get(None)
     if memory is None:
-        from .memory import MemoryStore  # Local import to avoid circular import
+        from .memory import (
+            _CHECKPOINT_DIR_ENV,
+            _RESUME_ENV,
+            _RUN_ID_ENV,
+            MemoryStore,
+        )  # Local import to avoid circular import
 
-        memory = MemoryStore()
+        run_id = os.environ.get(_RUN_ID_ENV)
+        checkpoint_dir_value = os.environ.get(_CHECKPOINT_DIR_ENV)
+        resume_flag = os.environ.get(_RESUME_ENV, "0").strip().lower() in {"1", "true", "yes"}
+
+        if run_id and checkpoint_dir_value:
+            checkpoint_dir = Path(checkpoint_dir_value)
+            memory = None
+            if resume_flag:
+                memory = MemoryStore.load_checkpoint(directory=checkpoint_dir, run_id=run_id)
+            if memory is None:
+                memory = MemoryStore()
+            memory.configure_checkpoint(directory=checkpoint_dir, run_id=run_id, auto_persist=True)
+        else:
+            memory = MemoryStore()
         _MEMORY_CTX.set(memory)
     return memory

--- a/tests/unit/vending_bench/test_memory_vector_store.py
+++ b/tests/unit/vending_bench/test_memory_vector_store.py
@@ -1,0 +1,176 @@
+"""Unit tests for the embedding-backed vector memory store."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from examples.vending_bench import memory as memory_module
+from examples.vending_bench.memory import (
+    DeterministicEmbeddingProvider,
+    EmbeddingCache,
+    MemoryStore,
+    vector_search,
+    vector_store,
+)
+
+
+def _build_memory(monkeypatch: pytest.MonkeyPatch, dimensions: int = 64) -> MemoryStore:
+    monkeypatch.setenv("VENDING_BENCH_EMBED_CACHE", "off")
+    store = MemoryStore(embedding_provider=DeterministicEmbeddingProvider(dimensions=dimensions))
+    monkeypatch.setattr("examples.vending_bench.memory.get_memory_store", lambda: store)
+    return store
+
+
+class TestVectorStoreEmbeddings:
+    """Validate that embeddings are generated and persisted when storing entries."""
+
+    def test_vector_store_generates_normalised_embedding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ = _build_memory(monkeypatch)
+        tool = vector_store()
+
+        result = tool("Restock energy drinks and water", metadata={"type": "email"})
+
+        assert result.entries, "vector_store should return the stored entry"
+        entry = result.entries[0]
+        assert entry.embedding, "embedding must be generated for stored entries"
+
+        norm = math.sqrt(sum(value * value for value in entry.embedding))
+        assert norm == pytest.approx(1.0, rel=1e-6, abs=1e-6)
+
+
+class TestVectorSearch:
+    """Validate cosine similarity ranking and thresholding."""
+
+    def test_vector_search_orders_by_similarity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ = _build_memory(monkeypatch)
+        store_tool = vector_store()
+        search_tool = vector_search()
+
+        store_tool("Plan restock for beverages", metadata={"id": "inventory"})
+        store_tool("Finalize quarterly financial statements", metadata={"id": "finance"})
+
+        result = search_tool("restock beverages plan", limit=2, similarity_threshold=0.0)
+
+        assert len(result.entries) == 2
+        top_ids = [entry.metadata.get("id") for entry in result.entries]
+        assert top_ids[0] == "inventory"
+        assert result.entries[0].similarity >= result.entries[1].similarity
+
+    def test_vector_search_applies_similarity_threshold(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _build_memory(monkeypatch)
+        store_tool = vector_store()
+        search_tool = vector_search()
+
+        store_tool("Prepare snack restock order", metadata={"topic": "inventory"})
+
+        result = search_tool("Completely unrelated topic", limit=5, similarity_threshold=0.95)
+
+        assert not result.entries
+
+
+class TestEmbeddingProviderResolution:
+    """Ensure deterministic fallback is available when OpenAI config is missing."""
+
+    def test_build_embedding_provider_falls_back_without_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("VENDING_BENCH_EMBEDDINGS", raising=False)
+        monkeypatch.delenv("VENDING_BENCH_EMBEDDING_DIM", raising=False)
+        monkeypatch.delenv("VENDING_BENCH_EMBEDDING_MODEL", raising=False)
+        memory_module._FALLBACK_WARNING_EMITTED = False
+
+        provider = memory_module._build_embedding_provider()
+
+        assert isinstance(provider, DeterministicEmbeddingProvider)
+
+
+class TestEmbeddingCache:
+    """Verify global embedding cache behaviour."""
+
+    class _CountingProvider:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def embed(self, text: str) -> list[float]:
+            self.calls += 1
+            return [1.0, 0.0, 0.0]
+
+        @property
+        def cache_id(self) -> str:
+            return "counting:3"
+
+    def test_cache_reuses_vectors(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VENDING_BENCH_EMBED_CACHE", "off")
+        provider = self._CountingProvider()
+        cache = EmbeddingCache(path=tmp_path / "cache.sqlite", mode="rw")
+        store = MemoryStore(embedding_provider=provider, embedding_cache=cache)
+
+        first = store.embed_text("Cache me once")
+        second = store.embed_text("Cache me once")
+
+        assert provider.calls == 1
+        assert first == pytest.approx(second)
+
+
+class TestMemoryCheckpointing:
+    """Ensure run checkpoints persist and isolate memory state."""
+
+    def test_checkpoint_round_trip(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VENDING_BENCH_EMBED_CACHE", "off")
+        run_id = "checkpoint-run"
+        directory = tmp_path / "checkpoints"
+
+        store = MemoryStore(embedding_provider=DeterministicEmbeddingProvider(dimensions=8))
+        store.configure_checkpoint(directory=directory, run_id=run_id, auto_persist=False)
+
+        store.scratchpad.append(
+            memory_module.ScratchpadEntry(
+                id="mem_000001",
+                content="Initial note",
+                timestamp=1.0,
+                day=0,
+                tags=["note"],
+                metadata={},
+            )
+        )
+        entry = memory_module.VectorEntry(
+            id="mem_000002",
+            content="Vector entry",
+            metadata={},
+            timestamp=1.0,
+            embedding=store.embed_text("Vector entry"),
+        )
+        store.vector_store.append(entry)
+        store.persist_checkpoint()
+
+        restored = MemoryStore.load_checkpoint(directory=directory, run_id=run_id)
+        assert restored is not None
+        assert len(restored.vector_store) == 1
+        assert restored.vector_store[0].embedding
+        assert restored.scratchpad[0].content == "Initial note"
+
+    def test_new_run_starts_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VENDING_BENCH_EMBED_CACHE", "off")
+        directory = tmp_path / "checkpoints"
+
+        run_a = MemoryStore(embedding_provider=DeterministicEmbeddingProvider(dimensions=8))
+        run_a.configure_checkpoint(directory=directory, run_id="run-a", auto_persist=False)
+        run_a.vector_store.append(
+            memory_module.VectorEntry(
+                id="mem_000010",
+                content="Persist me",
+                metadata={},
+                timestamp=1.0,
+                embedding=run_a.embed_text("Persist me"),
+            )
+        )
+        run_a.persist_checkpoint()
+
+        run_b = MemoryStore.load_checkpoint(directory=directory, run_id="run-b")
+        assert run_b is None
+
+        fresh = MemoryStore(embedding_provider=DeterministicEmbeddingProvider(dimensions=8))
+        fresh.configure_checkpoint(directory=directory, run_id="run-b", auto_persist=True)
+        assert fresh.vector_store == []

--- a/tests/unit/vending_bench/test_tools.py
+++ b/tests/unit/vending_bench/test_tools.py
@@ -36,6 +36,11 @@ from examples.vending_bench.tools import (
 from inspect_agents.exceptions import ToolException
 
 
+@pytest.fixture(autouse=True)
+def disable_embedding_cache(monkeypatch):
+    monkeypatch.setenv("VENDING_BENCH_EMBED_CACHE", "off")
+
+
 class TestToolParameterValidation:
     """Test parameter validation within tool execution."""
 
@@ -470,6 +475,7 @@ class TestScratchpadSummarise:
             content="Reference to first note",
             metadata={"source_ids": [original_entries[0].id]},
             timestamp=base_timestamp,
+            embedding=memory_store.embed_text("Reference to first note"),
         )
         memory_store.vector_store.append(vector_entry)
 


### PR DESCRIPTION
## What & Why

  Replaced the heuristic vector memory with cached embeddings and per-run checkpoints so Vending-Bench episodes can resume without recomputing embeddings or leaking state between runs. This supports Feature 1: real
  embedding-backed vector memory.

  Scope

  - Focused on Vending-Bench memory/runtime; no broader agent changes.

  ## Changes

  - Added SQLite-backed embedding cache with deterministic fallback and MemoryStore checkpoint serialization.
  - Wired runtime and CLI flags (--run-id, --resume-run, --memory-checkpoint-dir) to control per-run persistence.
  - Documented cache and checkpoint configuration in the Vending-Bench README.
  - Added unit suite covering cache hits, deterministic fallback, and checkpoint round trips; disabled cache in existing tool tests to isolate behavior.

  Affected areas

  - examples/vending_bench/memory.py
  - examples/vending_bench/runtime.py
  - examples/vending_bench/run.py
  - examples/vending_bench/README.md
  - tests/unit/vending_bench/

  ## Risk & Rollback

  Risk checklist

  - [ ] Breaking change (compat plan described)
  - [ ] Data migration/backfill (plan + window)
  - [ ] Security/privacy change (perms/secrets/PII)
  - [ ] Performance impact (baseline vs. new)
  - [ ] Observability updated (metrics/logs/alerts)
  - [ ] Feature flag (name, rollout, kill-switch tested)

  Rollback

  - git revert the three commits (memory cache, runtime wiring, tests/docs) or git reset --hard <previous-sha>; no data migration required.

  ## Test Plan

  Automated

  - Unit: CI=1 NO_NETWORK=1 PYTHONPATH=src:external/inspect_ai uv run --no_workspace pytest -q tests/unit/vending_bench/test_memory_vector_store.py tests/unit/vending_bench/test_tools.py

  Manual / Evidence

  - Steps + expected signals: n/a (pure code/test change)
  - UI (if applicable): n/a
  - Performance (if applicable): n/a

  ## Follow-ups (optional)

  - Monitor cache growth and consider eviction or metrics if production runs show unbounded size.
