### PR TITLE
refactor: centralize tool presets and descriptors

### DIFF
--- a/src/inspect_agents/agents.py
+++ b/src/inspect_agents/agents.py
@@ -30,61 +30,11 @@ BASE_PROMPT_TODOS = (
 BASE_PROMPT = BASE_PROMPT_HEADER + BASE_PROMPT_TODOS
 
 
-def _format_standard_tools_section(all_tools: list[object]) -> str:
-    """Return a short section enumerating available Inspect standard tools.
-
-    Groups standard tools separately so the model understands additional
-    capabilities beyond the Todo/FS utilities.
-    """
-    try:
-        from inspect_ai.tool._tool_def import ToolDef
-    except Exception:
-        # If ToolDef is unavailable (e.g., in stubs), skip annotation
-        return ""
-
-    names = set()
-    for t in all_tools:
-        try:
-            tdef = ToolDef(t) if not isinstance(t, ToolDef) else t
-            names.add(tdef.name)
-        except Exception:
-            pass
-
-    std_names: list[str] = []
-    # Detect presence of representative tools
-    if "think" in names:
-        std_names.append("think")
-    if "web_search" in names:
-        std_names.append("web_search")
-    if "bash" in names:
-        std_names.append("bash")
-    if "python" in names:
-        std_names.append("python")
-    # Web browser exposes multiple tool names; detect by go
-    browser_present = any(n.startswith("web_browser_") for n in names)
-    if browser_present:
-        std_names.append("web_browser")
-    if "text_editor" in names:
-        std_names.append("text_editor")
-
-    if not std_names:
-        return ""
-
-    std_list = ", ".join(std_names)
-    return (
-        "\n## Standard Tools\n\n"
-        f"Additional standard tools are enabled: {std_list}.\n"
-        "Use `web_search` to retrieve up‑to‑date information from the web when needed."
-        " Prefer citing sources in your answer.\n"
-    )
-
-
 def _built_in_tools():
-    # Local import to avoid importing inspect_ai at module import time
-    from inspect_agents.tools import full_safe_preset
+    # Use shared tool preset resolver
+    from .tool_presets import resolve_supervisor_tools
 
-    # Mirrors full_safe_preset() so defaults stay in sync with curated presets
-    return full_safe_preset()
+    return resolve_supervisor_tools(include_defaults=True)
 
 
 def build_supervisor(
@@ -136,7 +86,10 @@ def build_supervisor(
     tail_chunks = [BASE_PROMPT_HEADER]
     if resolved_include_defaults:
         tail_chunks.append(BASE_PROMPT_TODOS)
-    std_section = _format_standard_tools_section(tools)
+    # Use shared tool descriptor
+    from .tool_presets import describe_standard_tools
+
+    std_section = describe_standard_tools(tools)
     if std_section:
         tail_chunks.append(std_section)
     tail = "".join(tail_chunks)

--- a/src/inspect_agents/iterative.py
+++ b/src/inspect_agents/iterative.py
@@ -89,16 +89,13 @@ def _base_tools(*, code_only: bool = False) -> list[object]:
     - Always include Files tools (write/read/ls/edit).
     - When `code_only=True`, exclude all "standard" tools (think, exec, search,
       browser, etc.) regardless of environment flags.
-    - When `code_only=False` (default), append tools from `standard_tools()`
+    - When `code_only=False` (default), append tools from `resolve_standard_tools()`
       based on env toggles.
     """
-    from .tools import edit_file, ls, read_file, standard_tools, write_file
+    # Use shared tool preset resolver
+    from .tool_presets import resolve_iterative_tools
 
-    fs_tools = [write_file(), read_file(), ls(), edit_file()]
-    if code_only:
-        return fs_tools
-    # Core FS tools + any enabled standard tools (think, web_search, exec, etc.)
-    return fs_tools + standard_tools()
+    return resolve_iterative_tools(include_defaults=True, code_only=code_only)
 
 
 def _default_system_message(*, code_only: bool = False, include_defaults: bool = True) -> str:

--- a/src/inspect_agents/tool_presets.py
+++ b/src/inspect_agents/tool_presets.py
@@ -1,0 +1,237 @@
+"""Centralized tool presets and descriptors for inspect_agents.
+
+This module provides a single source of truth for tool resolution logic,
+prompt descriptions, and preset composition to eliminate duplication
+across supervisor and iterative agents.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from .settings import truthy
+
+
+def _use_sandbox_fs() -> bool:
+    """Check if sandbox filesystem mode is enabled."""
+    return os.getenv("INSPECT_AGENTS_FS_MODE", "").strip().lower() == "sandbox"
+
+
+def resolve_standard_tools() -> list[object]:
+    """Resolve standard Inspect‑AI tools based on environment configuration.
+
+    Controlled by environment flags to keep defaults safe:
+
+    - INSPECT_ENABLE_THINK: enable `think()` (default: true)
+    - INSPECT_ENABLE_WEB_SEARCH: enable `web_search(...)` when a provider is available
+      (default: auto if Tavily or Google keys are set)
+    - INSPECT_ENABLE_EXEC: enable `bash()` and `python()` (default: false)
+    - INSPECT_ENABLE_WEB_BROWSER: enable `web_browser(...)` tools (default: false)
+    - INSPECT_ENABLE_TEXT_EDITOR_TOOL: expose `text_editor()` as a tool (default: false)
+
+    Notes:
+    - Our file tools (read_file/write_file/edit_file/ls) already use `text_editor`
+      internally when `INSPECT_AGENTS_FS_MODE=sandbox`; exposing `text_editor()`
+      directly is optional and disabled by default.
+    - Web search providers are auto‑configured using environment variables:
+      Tavily (TAVILY_API_KEY) or Google CSE (GOOGLE_CSE_ID/GOOGLE_CSE_API_KEY).
+    """
+    tools: list[object] = []
+
+    # Local imports to avoid heavy imports at module import time
+    try:
+        from inspect_ai.tool import think, web_search
+        from inspect_ai.tool._tools._execute import bash
+        from inspect_ai.tool._tools._execute import python as py_exec
+        from inspect_ai.tool._tools._text_editor import text_editor
+        from inspect_ai.tool._tools._web_browser import web_browser
+    except Exception:
+        # If inspect_ai is stubbed in tests, just return empty; callers can still use our built‑ins
+        return tools
+
+    # think()
+    if not os.getenv("INSPECT_ENABLE_THINK") or truthy(os.getenv("INSPECT_ENABLE_THINK", "1")):
+        try:
+            tools.append(think())
+        except Exception:
+            pass
+
+    # web_search(...)
+    enable_web_search_env = os.getenv("INSPECT_ENABLE_WEB_SEARCH")
+    enable_web_search = (
+        truthy(enable_web_search_env)
+        if enable_web_search_env is not None
+        else (os.getenv("TAVILY_API_KEY") or (os.getenv("GOOGLE_CSE_ID") and os.getenv("GOOGLE_CSE_API_KEY")))
+        is not None
+    )
+    if enable_web_search:
+        try:
+            providers_cfg: list[object] = []
+            # Prefer internal provider if user explicitly requests via INSPECT_WEB_SEARCH_INTERNAL
+            internal = (os.getenv("INSPECT_WEB_SEARCH_INTERNAL") or "").strip().lower()
+            if internal in {"openai", "anthropic", "perplexity", "gemini", "grok"}:
+                providers_cfg.append(internal)
+
+            # Add external providers based on available credentials
+            if os.getenv("TAVILY_API_KEY"):
+                providers_cfg.append({"tavily": True})
+            if os.getenv("GOOGLE_CSE_ID") and os.getenv("GOOGLE_CSE_API_KEY"):
+                providers_cfg.append({"google": True})
+
+            providers = providers_cfg or None
+            tools.append(web_search(providers))
+        except Exception:
+            # If provider configuration is invalid or missing, skip silently
+            pass
+
+    # bash() and python() (disabled by default)
+    if truthy(os.getenv("INSPECT_ENABLE_EXEC")):
+        try:
+            tools.extend([bash(), py_exec()])
+        except Exception:
+            pass
+
+    # web_browser (disabled by default; heavy)
+    if truthy(os.getenv("INSPECT_ENABLE_WEB_BROWSER")):
+        try:
+            tools.extend(web_browser())
+        except Exception:
+            pass
+
+    # text_editor (disabled by default; only meaningful with sandbox FS)
+    if truthy(os.getenv("INSPECT_ENABLE_TEXT_EDITOR_TOOL")) and _use_sandbox_fs():
+        try:
+            tools.append(text_editor())
+        except Exception:
+            pass
+
+    # Defensive policy: never surface any stateful shell session tool here.
+    # In this repo, `bash_session` is reserved for internal FS sandbox plumbing
+    # (see fs_adapter) and must not be exposed via the public `standard_tools()`
+    # helper regardless of upstream defaults or env toggles.
+    try:
+        filtered: list[object] = []
+        for t in tools:
+            try:
+                name = getattr(t, "name", None) or getattr(t, "__name__", None)
+                if isinstance(name, str) and name.strip().lower() == "bash_session":
+                    logging.getLogger(__name__).warning(
+                        "Filtered out stateful tool 'bash_session' from standard_tools (internal-only)."
+                    )
+                    continue
+            except Exception:
+                # If we cannot introspect, keep the tool (fail-open) — tests enforce the policy.
+                pass
+            filtered.append(t)
+        tools = filtered
+    except Exception:
+        # Never fail construction due to filtering; tests will catch regressions.
+        pass
+
+    return tools
+
+
+def describe_standard_tools(all_tools: list[object]) -> str:
+    """Return a prompt section describing available Inspect standard tools.
+
+    Groups standard tools separately so the model understands additional
+    capabilities beyond the Todo/FS utilities.
+    """
+    try:
+        from inspect_ai.tool._tool_def import ToolDef
+    except Exception:
+        # If ToolDef is unavailable (e.g., in stubs), skip annotation
+        return ""
+
+    names = set()
+    for t in all_tools:
+        try:
+            tdef = ToolDef(t) if not isinstance(t, ToolDef) else t
+            names.add(tdef.name)
+        except Exception:
+            pass
+
+    std_names: list[str] = []
+    # Detect presence of representative tools
+    if "think" in names:
+        std_names.append("think")
+    if "web_search" in names:
+        std_names.append("web_search")
+    if "bash" in names:
+        std_names.append("bash")
+    if "python" in names:
+        std_names.append("python")
+    # Web browser exposes multiple tool names; detect by go
+    browser_present = any(n.startswith("web_browser_") for n in names)
+    if browser_present:
+        std_names.append("web_browser")
+    if "text_editor" in names:
+        std_names.append("text_editor")
+
+    if not std_names:
+        return ""
+
+    std_list = ", ".join(std_names)
+    return (
+        "\n## Standard Tools\n\n"
+        f"Additional standard tools are enabled: {std_list}.\n"
+        "Use `web_search` to retrieve up‑to‑date information from the web when needed."
+        " Prefer citing sources in your answer.\n"
+    )
+
+
+def resolve_builtin_tools(*, include_defaults: bool, code_only: bool = False) -> list[object]:
+    """Resolve the complete builtin toolset based on configuration.
+
+    Args:
+        include_defaults: Whether to include default tools (todos, fs tools)
+        code_only: If True, exclude standard tools regardless of env flags
+
+    Returns:
+        List of resolved tools combining defaults and standard tools as appropriate
+    """
+    tools: list[object] = []
+
+    # Add default tools if requested
+    if include_defaults:
+        from .tools import minimal_fs_preset
+
+        tools.extend(minimal_fs_preset())
+
+    # Add standard tools unless code_only mode
+    if not code_only:
+        tools.extend(resolve_standard_tools())
+
+    return tools
+
+
+def resolve_supervisor_tools(*, include_defaults: bool) -> list[object]:
+    """Resolve tools for the supervisor agent."""
+    if include_defaults:
+        from .tools import full_safe_preset
+
+        return full_safe_preset()
+    return []
+
+
+def resolve_iterative_tools(*, include_defaults: bool, code_only: bool = False) -> list[object]:
+    """Resolve tools for the iterative agent.
+
+    - Always include Files tools (write/read/ls/edit) when include_defaults is True.
+    - When `code_only=True`, exclude all "standard" tools (think, exec, search,
+      browser, etc.) regardless of environment flags.
+    - When `code_only=False` (default), append tools from `resolve_standard_tools()`
+      based on env toggles.
+    """
+    tools: list[object] = []
+
+    if include_defaults:
+        from .tools import edit_file, ls, read_file, write_file
+
+        tools.extend([write_file(), read_file(), ls(), edit_file()])
+
+    if not code_only:
+        tools.extend(resolve_standard_tools())
+
+    return tools

--- a/src/inspect_agents/tools.py
+++ b/src/inspect_agents/tools.py
@@ -27,9 +27,6 @@ import logging
 from . import fs as _fs
 from .exceptions import ToolException
 from .settings import (
-    truthy as _truthy,
-)
-from .settings import (
     typed_results_enabled as _use_typed_results,
 )
 from .state import Todo, Todos
@@ -132,115 +129,12 @@ class TodoStatusResult(BaseModel):
 def standard_tools() -> list[object]:
     """Return a list of standard Inspect‑AI tools.
 
-    Controlled by environment flags to keep defaults safe:
-
-    - INSPECT_ENABLE_THINK: enable `think()` (default: true)
-    - INSPECT_ENABLE_WEB_SEARCH: enable `web_search(...)` when a provider is available
-      (default: auto if Tavily or Google keys are set)
-    - INSPECT_ENABLE_EXEC: enable `bash()` and `python()` (default: false)
-    - INSPECT_ENABLE_WEB_BROWSER: enable `web_browser(...)` tools (default: false)
-    - INSPECT_ENABLE_TEXT_EDITOR_TOOL: expose `text_editor()` as a tool (default: false)
-
-    Notes:
-    - Our file tools (read_file/write_file/edit_file/ls) already use `text_editor`
-      internally when `INSPECT_AGENTS_FS_MODE=sandbox`; exposing `text_editor()`
-      directly is optional and disabled by default.
-    - Web search providers are auto‑configured using environment variables:
-      Tavily (TAVILY_API_KEY) or Google CSE (GOOGLE_CSE_ID/GOOGLE_CSE_API_KEY).
+    Delegates to the centralized tool preset resolver to maintain
+    compatibility while avoiding duplication.
     """
-    tools: list[object] = []
+    from .tool_presets import resolve_standard_tools
 
-    # Local imports to avoid heavy imports at module import time
-    try:
-        from inspect_ai.tool import think, web_search
-        from inspect_ai.tool._tools._execute import bash
-        from inspect_ai.tool._tools._execute import python as py_exec
-        from inspect_ai.tool._tools._text_editor import text_editor
-        from inspect_ai.tool._tools._web_browser import web_browser
-    except Exception:
-        # If inspect_ai is stubbed in tests, just return empty; callers can still use our built‑ins
-        return tools
-
-    # think()
-    if not os.getenv("INSPECT_ENABLE_THINK") or _truthy(os.getenv("INSPECT_ENABLE_THINK", "1")):
-        try:
-            tools.append(think())
-        except Exception:
-            pass
-
-    # web_search(...)
-    enable_web_search_env = os.getenv("INSPECT_ENABLE_WEB_SEARCH")
-    enable_web_search = (
-        _truthy(enable_web_search_env)
-        if enable_web_search_env is not None
-        else (os.getenv("TAVILY_API_KEY") or (os.getenv("GOOGLE_CSE_ID") and os.getenv("GOOGLE_CSE_API_KEY")))
-        is not None
-    )
-    if enable_web_search:
-        try:
-            providers_cfg: list[object] = []
-            # Prefer internal provider if user explicitly requests via INSPECT_WEB_SEARCH_INTERNAL
-            internal = (os.getenv("INSPECT_WEB_SEARCH_INTERNAL") or "").strip().lower()
-            if internal in {"openai", "anthropic", "perplexity", "gemini", "grok"}:
-                providers_cfg.append(internal)
-
-            # Add external providers based on available credentials
-            if os.getenv("TAVILY_API_KEY"):
-                providers_cfg.append({"tavily": True})
-            if os.getenv("GOOGLE_CSE_ID") and os.getenv("GOOGLE_CSE_API_KEY"):
-                providers_cfg.append({"google": True})
-
-            providers = providers_cfg or None
-            tools.append(web_search(providers))
-        except Exception:
-            # If provider configuration is invalid or missing, skip silently
-            pass
-
-    # bash() and python() (disabled by default)
-    if _truthy(os.getenv("INSPECT_ENABLE_EXEC")):
-        try:
-            tools.extend([bash(), py_exec()])
-        except Exception:
-            pass
-
-    # web_browser (disabled by default; heavy)
-    if _truthy(os.getenv("INSPECT_ENABLE_WEB_BROWSER")):
-        try:
-            tools.extend(web_browser())
-        except Exception:
-            pass
-
-    # text_editor (disabled by default; only meaningful with sandbox FS)
-    if _truthy(os.getenv("INSPECT_ENABLE_TEXT_EDITOR_TOOL")) and _use_sandbox_fs():
-        try:
-            tools.append(text_editor())
-        except Exception:
-            pass
-
-    # Defensive policy: never surface any stateful shell session tool here.
-    # In this repo, `bash_session` is reserved for internal FS sandbox plumbing
-    # (see fs_adapter) and must not be exposed via the public `standard_tools()`
-    # helper regardless of upstream defaults or env toggles.
-    try:
-        filtered: list[object] = []
-        for t in tools:
-            try:
-                name = getattr(t, "name", None) or getattr(t, "__name__", None)
-                if isinstance(name, str) and name.strip().lower() == "bash_session":
-                    logging.getLogger(__name__).warning(
-                        "Filtered out stateful tool 'bash_session' from standard_tools (internal-only)."
-                    )
-                    continue
-            except Exception:
-                # If we cannot introspect, keep the tool (fail-open) — tests enforce the policy.
-                pass
-            filtered.append(t)
-        tools = filtered
-    except Exception:
-        # Never fail construction due to filtering; tests will catch regressions.
-        pass
-
-    return tools
+    return resolve_standard_tools()
 
 
 def minimal_fs_preset() -> list[object]:


### PR DESCRIPTION
## What & Why

Centralize default tool resolution and prompt copy to eliminate duplication across supervisor and iterative agents. Currently, multiple modules duplicate logic for composing tool lists and describing them in prompts, making it difficult to maintain when toggles change or new tools are added.

**Scope**
- Create shared descriptor module for tool resolution and prompt generation
- Update supervisor and iterative builders to use centralized logic
- Maintain backward compatibility with existing APIs

## Changes
- New `src/inspect_agents/tool_presets.py` module with centralized functions:
  - `resolve_standard_tools()`: Core tool resolution with environment flags
  - `describe_standard_tools()`: Unified prompt description logic  
  - `resolve_supervisor_tools()`: Supervisor-specific tool resolution
  - `resolve_iterative_tools()`: Iterative agent tool resolution with code_only support
- Updated `agents.py` to use shared descriptors instead of duplicated logic
- Updated `iterative.py` to use centralized tool resolution
- Updated `tools.py` `standard_tools()` to delegate to centralized resolver

**Affected areas**
- `src/inspect_agents/tool_presets.py` (new)
- `src/inspect_agents/agents.py`
- `src/inspect_agents/iterative.py`  
- `src/inspect_agents/tools.py`

## Risk & Rollback

**Risk checklist**
- [ ] Breaking change (compat plan described) - No breaking changes, all public APIs maintained
- [ ] Data migration/backfill (plan + window) - N/A
- [ ] Security/privacy change (perms/secrets/PII) - N/A
- [ ] Performance impact (baseline vs. new) - Minimal, same logic paths with delegation
- [ ] Observability updated (metrics/logs/alerts) - N/A
- [ ] Feature flag (name, rollout, kill-switch tested) - N/A

**Rollback**
Simple revert of this commit - no data changes or migrations required.

## Test Plan

**Automated**
- Unit: All existing tests continue to pass with centralized resolution
- Verified success criteria: `grep "Additional standard tools"` shows single definition
- Environment flag testing: `INSPECT_ENABLE_THINK=0` correctly disables tools
- Include defaults flag testing: Both `True`/`False` work for supervisor and iterative agents

**Manual / Evidence** 
- Verified agent creation works correctly with new centralized logic
- Tool count verification: Normal vs code-only modes work as expected
- Prompt description format maintained: "Additional standard tools are enabled:" pattern preserved
- Backward compatibility: All existing functions (`standard_tools()`, `full_safe_preset()`, etc.) work via delegation

## Follow-ups

Future tool additions now only require touching the centralized `tool_presets.py` module.