### PR TITLE
fix: update migration.py to use centralized tool descriptor

### DIFF
--- a/src/inspect_agents/migration.py
+++ b/src/inspect_agents/migration.py
@@ -250,9 +250,9 @@ def create_deep_agent(
     from inspect_agents.agents import (
         BASE_PROMPT_HEADER,
         BASE_PROMPT_TODOS,
-        _format_standard_tools_section,
         build_subagents,
     )
+    from inspect_agents.tool_presets import describe_standard_tools
 
     # Resolve built-ins and optional sub-agents
     resolved_include_defaults, _, _ = resolve_include_defaults(include_defaults)
@@ -270,7 +270,7 @@ def create_deep_agent(
     tail_chunks = [BASE_PROMPT_HEADER]
     if resolved_include_defaults:
         tail_chunks.append(BASE_PROMPT_TODOS)
-    std_section = _format_standard_tools_section(base_tools + extra_tools)
+    std_section = describe_standard_tools(base_tools + extra_tools)
     if std_section:
         tail_chunks.append(std_section)
 


### PR DESCRIPTION
Update migration.py to import describe_standard_tools from the new tool_presets module instead of the removed _format_standard_tools_section function from agents.py. This ensures all modules use the centralized tool description logic.

